### PR TITLE
Fix docs build

### DIFF
--- a/.github/actions/cicd-setup/action.yml
+++ b/.github/actions/cicd-setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install freegsnke and dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/actions/cicd-setup/action.yml
+++ b/.github/actions/cicd-setup/action.yml
@@ -11,10 +11,5 @@ runs:
     - name: Install freegsnke and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ".[freegs4e,dev]"
-      shell: bash
-    - name: Install docs dependencies
-      run: |
-        cd docs
-        pip install -r requirements_docs.txt
+        pip install ".[freegs4e,dev,docs]"
       shell: bash

--- a/.github/actions/cicd-setup/action.yml
+++ b/.github/actions/cicd-setup/action.yml
@@ -13,3 +13,8 @@ runs:
         python -m pip install --upgrade pip
         pip install ".[freegs4e,dev]"
       shell: bash
+    - name: Install docs dependencies
+      run: |
+        cd docs
+        pip install -r requirements_docs.txt
+      shell: bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,24 +2,30 @@
 
 The documentation is built using Sphinx and is partially automatically generated from the code.
 
+The documentation is available at [docs.freegsnke.com](https://docs.freegsnke.com/).
 
-## API documentation
 
-The requirements for building the documentation are kept separate from the FreeGSNKE requirements. FreeGSNKE and its dependencies are required to be installed to build the docs (see the README in the repository root directory for instructions).
+## Building the documentation
 
-To install the documentation requirements, run the following command from the `docs` directory. Ensure that the active programming environment has FreeGSNKE installed.
+To build the documentation locally, first install FreeGSNKE with the `docs` extra. For example, the following command may be run from the FreeGSNKE root directory:
 
 ```bash
-pip install -r requirements_docs.txt
+pip install ".[docs]"
 ```
 
-The documentation can then be built by running:
+Other extras can be installed at the same time, for example:
+
+```bash
+pip install -e ".[freegs4e,dev,docs]"
+```
+
+The documentation can then be built by running the following command from the `docs/` directory:
 
 ```bash
 bash build_documentation.sh
 ```
 
-This may take several minutes to complete as it runs some examples of the code to generate the documentation.
+This may take several minutes to complete as some examples of the code are run to generate the documentation.
 
 ## Viewing the documentation
 

--- a/docs/build_documentation.sh
+++ b/docs/build_documentation.sh
@@ -12,6 +12,7 @@ cp "../examples/example4 - using_magnetic_probes.ipynb" notebooks
 cp "../examples/example5 - evolutive_forward_solve.ipynb" notebooks
 cp "../examples/example7 - static_inverse_solve_SPARC.ipynb" notebooks
 cp "../examples/example8 - static_inverse_solve_ITER.ipynb" notebooks
+cp "../examples/example9 - virtual_circuits_MASTU.ipynb" notebooks
 cp ../examples/limiter_currents.json notebooks
 cp ../examples/simple_diverted_currents_PaxisIp.pk notebooks
 cp ../examples/simple_limited_currents_PaxisIp.pk notebooks

--- a/docs/build_documentation.sh
+++ b/docs/build_documentation.sh
@@ -27,11 +27,6 @@ cp -r ../machine_configs/MAST-U machine_configs
 cp -r ../machine_configs/SPARC machine_configs
 cp -r ../machine_configs/ITER machine_configs
 
-export ACTIVE_COILS_PATH=../machine_configs/MAST-U/MAST-U_like_active_coils.pickle
-export PASSIVE_COILS_PATH=../machine_configs/MAST-U/MAST-U_like_passive_coils.pickle
-export WALL_PATH=../machine_configs/MAST-U/MAST-U_like_wall.pickle
-export LIMITER_PATH=../machine_configs/MAST-U/MAST-U_like_limiter.pickle
-
 echo "Generating API documentation"
 sphinx-apidoc -e -f --no-toc -o api/ ../freegsnke/
 

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,9 +1,0 @@
-sphinx
-sphinx-math-dollar
-sphinx-rtd-dark-mode
-sphinx-rtd-theme
-sphinx-autobuild
-ipython
-m2r2
-myst-nb
-docutils<0.21

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -19,3 +19,4 @@ The notebooks are displayed statically on the following pages, but running them 
     ../notebooks/example5 - evolutive_forward_solve
     ../notebooks/example7 - static_inverse_solve_SPARC
     ../notebooks/example8 - static_inverse_solve_ITER
+    ../notebooks/example9 - virtual_circuits_MASTU

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = {file = ["requirements.txt"]}
 optional-dependencies.dev =  { file = ["requirements-dev.txt"] }
 optional-dependencies.freegs4e = { file = ["requirements-freegs4e.txt"] }
 optional-dependencies.uda = { file = ["requirements-uda.txt"] }
+optional-dependencies.docs = { file = ["requirements-docs.txt"] }
 
 [project.urls]
 Homepage = "https://github.com/FusionComputingLab/freegsnke"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,10 @@
+sphinx==8.1.3
+sphinx-math-dollar==1.2.1
+sphinx-rtd-dark-mode==1.3.0
+sphinx-rtd-theme==3.0.2
+sphinx-autobuild==2024.10.03
+ipython==8.36.0
+m2r2==0.3.4
+myst-nb==1.2.0
+docutils==0.21.2
+mistune==0.8.4

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,3 +8,4 @@ m2r2==0.3.4
 myst-nb==1.2.0
 docutils==0.21.2
 mistune==0.8.4
+lxml_html_clean==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-scipy~=1.9
-numpy~=1.22
-matplotlib~=3.5
-h5py~=3.7
-deepdiff~=7.0
-notebook~=7.2
+scipy~=1.15.3
+numpy~=1.26.4
+matplotlib~=3.10.3
+h5py~=3.13.0
+deepdiff~=7.0.1
+notebook~=7.4.2


### PR DESCRIPTION
- Incorporate docs requirements into pip extras. Now installed with `pip install .[docs]`
- Added example 9 to docs examples index
- Bumped python version of github action cicd-setup to 3.10

Addresses #9 