### PR TITLE
Uda dependency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ FreeGSNKE also interfaces with [UDA](https://github.com/ukaea/UDA), for example,
 
 1. Log into your account at https://git.ccfe.ac.uk/ and follow the instructions [here](https://docs.gitlab.com/user/ssh/) to set up an SSH key to communicate with the CCFE GitLab instance.
 2. Establish a connection to the UKAEA VPN.
-3. When installing FreeGSNKE, specify the `uda` extra: `pip install freegsnke[uda]`. To install both the `uda` and `freegs4e` extras, separate them with a comma: `pip install freegsnke[freegs4e,uda]`.
+3. When installing FreeGSNKE, specify the `uda` extra: `pip install freegsnke[uda]`.
+4. Finally, install the uda-mast package: `pip install "uda-mast @ git+ssh://git@git.ccfe.ac.uk/MAST-U/mastcodes.git@1.3.10#subdirectory=uda/python"`.
 
 ## Contributing
 

--- a/requirements-uda.txt
+++ b/requirements-uda.txt
@@ -1,2 +1,1 @@
 uda
-uda-mast @ git+ssh://git@git.ccfe.ac.uk/MAST-U/mastcodes.git@1.3.10#subdirectory=uda/python


### PR DESCRIPTION
Update UDA dependency installation so that FreeGSNKE can be published to PyPI.

Previously, publishing was failing because the uda-mast dependency was specified as a direct dependency as part of the `uda` extra, which is not PEP compliant and therefore not supported by PyPI. Relevant issue: https://github.com/pypi/warehouse/issues/7136

Fixed by removing the direct dependency from the optional `uda` extra, and specified how to install uda-mast in the readme.