### PR TITLE
Remove ITER example from notebooks CI workflow

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -29,5 +29,3 @@ jobs:
         run: jupyter nbconvert --execute --to notebook --inplace "examples/example5 - evolutive_forward_solve.ipynb"
       - name: Check static inverse solve SPARC notebook
         run: jupyter nbconvert --execute --to notebook --inplace "examples/example7 - static_inverse_solve_SPARC.ipynb"
-      - name: Check static inverse solve ITER notebook
-        run: jupyter nbconvert --execute --to notebook --inplace "examples/example8 - static_inverse_solve_ITER.ipynb"


### PR DESCRIPTION
The ITER notebook example is currently failing due to some required solver parameter tweaks