### PR TITLE
Run docs build and deploy from docs directory

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,7 +17,7 @@ jobs:
       uses: './.github/actions/cicd-setup'
 
     - name: Build docs
-      run: bash docs/build_documentation.sh
+      run: cd docs && bash docs/build_documentation.sh
 
     - name: Deploy docs to netlify
-      run: netlify deploy --site ${{ secrets.NETLIFY_SITE_ID }}  --auth ${{ secrets.NETLIFY_DOCS_DEPLOY_API_TOKEN }} --prod --dir docs/_build/html
+      run: cd docs && netlify deploy --site ${{ secrets.NETLIFY_SITE_ID }}  --auth ${{ secrets.NETLIFY_DOCS_DEPLOY_API_TOKEN }} --prod --dir _build/html


### PR DESCRIPTION
Docs build and deploy was failing. Needs to run with the docs directory as working directory.