### PR TITLE
Remove expensive deepcopies

### DIFF
--- a/freegsnke/GSstaticsolver.py
+++ b/freegsnke/GSstaticsolver.py
@@ -233,7 +233,7 @@ class NKGSsolver:
         eq.flag_limiter = profiles.flag_limiter
 
         eq._current = np.sum(profiles.jtor) * self.dRdZ
-        eq._profiles = deepcopy(profiles)
+        eq._profiles = profiles
 
         try:
             eq.tokamak_psi = self.tokamak_psi.reshape(self.nx, self.ny)

--- a/freegsnke/equilibrium_update.py
+++ b/freegsnke/equilibrium_update.py
@@ -62,6 +62,58 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
             float
         )
 
+    def create_auxiliary_equilibrium(self):
+        """Creates the auxiliary equilibrium object.
+
+        The auxiliary object returned from this method is essentially
+        a copy of the equilibrium object (self) however it is manually
+        setup and so won't contain all attributes on self (especially custom
+        attributes). It is NOT _guaranteed_ to be the same as a deepcopy, or even
+        a shallow copy.
+        """
+        # __new__ stops __init__ being called.
+        # This is necessary because the __init__ method does expensive
+        # calculations which we can just copy the results of
+        equilibrium = Equilibrium.__new__(Equilibrium)
+
+        # attributes that FreeGS4e sets
+        equilibrium.tokamak = self.tokamak
+        equilibrium.Rmin = self.Rmin
+        equilibrium.Rmax = self.Rmax
+        equilibrium.Zmin = self.Zmin
+        equilibrium.Zmax = self.Zmax
+        equilibrium.nx = self.nx
+        equilibrium.ny = self.ny
+        equilibrium.dR = self.dR
+        equilibrium.dZ = self.dZ
+        equilibrium._applyBoundary = self._applyBoundary
+        equilibrium._pgreen = self._pgreen
+        equilibrium._vgreen = self._vgreen
+        equilibrium._current = self._current
+        equilibrium.order = self.order
+        equilibrium._solver = self._solver
+
+        # attributes the FreeGSNKE sets
+        equilibrium.solved = self.solved
+        equilibrium.psi_func_interp = self.psi_func_interp
+        equilibrium.nxh = self.nxh
+        equilibrium.nyh = self.nyh
+        equilibrium.Rnxh = self.Rnxh
+        equilibrium.Znyh = self.Znyh
+        equilibrium.limiter_handler = self.limiter_handler  # should be safe not to copy
+
+        # attributes that actually need to be copied
+        equilibrium.R_1D = np.copy(self.R_1D)
+        equilibrium.Z_1D = np.copy(self.Z_1D)
+        equilibrium.R = np.copy(self.R)
+        equilibrium.Z = np.copy(self.Z)
+        equilibrium.tokamak_psi = np.copy(self.tokamak_psi)
+        equilibrium.plasma_psi = np.copy(self.plasma_psi)
+        equilibrium.mask_inside_limiter = np.copy(self.mask_inside_limiter)
+        equilibrium.mask_outside_limiter = np.copy(self.mask_outside_limiter)
+
+        return equilibrium
+
     def adjust_psi_plasma(
         self,
     ):

--- a/freegsnke/nonlinear_solve.py
+++ b/freegsnke/nonlinear_solve.py
@@ -2125,7 +2125,8 @@ class nl_solver:
 
         if from_linear:
             self.profiles1 = self.profiles2
-            self.eq1 = deepcopy(self.eq2)
+            self.eq1 = self.eq2
+            self.eq2 = self.eq1.create_auxiliary_equilibrium()
         else:
             self.eq1.plasma_psi = np.copy(self.trial_plasma_psi)
             self.profiles1.Ip = self.trial_currents[-1] * self.plasma_norm_factor

--- a/freegsnke/nonlinear_solve.py
+++ b/freegsnke/nonlinear_solve.py
@@ -2124,7 +2124,7 @@ class nl_solver:
         self.eq2.tokamak.set_all_coil_currents(self.vessel_currents_vec)
 
         if from_linear:
-            self.profiles1 = deepcopy(self.profiles2)
+            self.profiles1 = self.profiles2
             self.eq1 = deepcopy(self.eq2)
         else:
             self.eq1.plasma_psi = np.copy(self.trial_plasma_psi)


### PR DESCRIPTION
Removes expensive deepcopies of profile and equilibrium objects inside the evolutive loop. 

The following table shows the % of the runtime for a 60 iteration example evolutive run that is spent deep copying objects.
| | Linear| Non-linear |
| -- | -- | -- |
| `main (10615f0)` | $11.17$% | $5.82$% |
| This PR | $1.02$% | $0.20$% |

Overall, this results in a reduction in runtime spent in `stepping.nlstepper` (linear evolutive example): going from $21.12$% on main to $13.28$% on this branch.

I have compared history arrays of the coil currents, o-points, elongation, triangularity, squareness, separatrix area, and separatrix length between `main` and this PR. There is a 0 MAE between the non-linear example histories on main and in this PR, and a 0 MAE between the linear histories on main and in this PR. 

I have confirmed that example 01, 02, 03, 04, 05, 09, and 10 can run on this branch and produce the same results as on main. Example 01 appears to be non-deterministic on main and this behaviour continues on this branch, however the plots are qualitatively similar and the numbers are of the same magnitude.