### PR TITLE
Update parameters for ITER example inverse solve

### DIFF
--- a/examples/example08 - static_inverse_solve_ITER.ipynb
+++ b/examples/example08 - static_inverse_solve_ITER.ipynb
@@ -115,15 +115,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# initialise the profiles\n",
-    "from freegsnke.jtor_update import ConstrainBetapIp\n",
-    "profiles = ConstrainBetapIp(\n",
-    "    eq=eq,        # equilibrium object\n",
-    "    betap=0.15,   # poloidal beta\n",
-    "    Ip=11e6,      # plasma current\n",
-    "    fvac=0.5,     # fvac = rB_{tor}\n",
-    "    alpha_m=2.0,  # profile function parameter\n",
-    "    alpha_n=1.0   # profile function parameter\n",
+    "from freegsnke.jtor_update import Fiesta_Topeol\n",
+    "profiles = Fiesta_Topeol(\n",
+    "    eq=eq,\n",
+    "    Beta0=0.5978,\n",
+    "    Ip=15e6,\n",
+    "    fvac=0.5,\n",
+    "    Raxis=6.2,\n",
+    "    alpha_m=2.0,\n",
+    "    alpha_n=1.395\n",
     ")"
    ]
   },
@@ -257,6 +257,8 @@
     "                    #  max_rel_psit=.05,\n",
     "                     verbose=True, # print output\n",
     "                     l2_reg=1e-14,\n",
+    "                     Picard_handover=1e-4,\n",
+    "                     full_jacobian_handover=[1e-3, 1e-2]\n",
     "                     )\n"
    ]
   },
@@ -291,25 +293,11 @@
     "# with open('simple_diverted_currents_PaxisIp.pk', 'wb') as f:\n",
     "#     pickle.dump(obj=inverse_current_values, file=f)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "freegsnke4e",
+   "display_name": "freegsnke-dev",
    "language": "python",
    "name": "python3"
   },
@@ -323,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated ITER example with improved parameter provided by @ubaidali in #18. This includes changing the profile constraint to use `FiestaTopeol` instead of `ConstrainBetapIp`. Seeing #18 for an equivalent set of parameters using `ConstrainBetapIp`.