### PR TITLE
Add beta_p/li profile targets to pulse design example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,5 +19,6 @@ These example Jupyter notebooks are intended to be the **first port of call for 
 | Example 09 | Learn how to use and build virtual circuits for plasma shape control. | Anyone |
 | Example 10 | Learn how to calculate growth rates associated with vertically unstable modes. | Anyone |
 | Example 11 | Learn how to use the evolutive solver alongside a virtual plasma control system (FreeGSNKE Pulse Design Tool). | Anyone |
+| Example 11b | Learn how to use the Pulse Design Tool while prescribing Lao profile evolution through beta_p and li targets. | Anyone |
 
 If a new example has been created, please add a new line to the table explaining its purpose!

--- a/examples/example11b - pulse_design_tool_betap_li.ipynb
+++ b/examples/example11b - pulse_design_tool_betap_li.ipynb
@@ -1,0 +1,8235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example: Pulse Design Tool with beta_p/li profile targets\n",
+    "\n",
+    "This notebook demonstrates how to use the **FreeGSNKE Pulse Design Tool** (FPDT) in the same toy scenario as Example 11, but with the plasma current density profile evolution prescribed through physical `beta_p` and `li` targets rather than by directly prescribing Lao `alpha` and `beta` coefficients.\n",
+    "\n",
+    "The virtual PCS setup, controller waveforms, machine, and initial condition are otherwise the same as Example 11. The underlying profile object remains `Lao85`; before each dynamic timestep, FreeGSNKE fits the Lao coefficients that reproduce the requested `beta_p` and `li` targets and then advances the existing evolutive solver using the corresponding coefficient change.\n",
+    "\n",
+    "For this toy case there is no EFIT reconstruction. We therefore calculate `beta_p` and `li` from the initial FreeGSNKE equilibrium and keep both quantities constant throughout the dynamic solve.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate a starting equilibrum\n",
+    "\n",
+    "As in prior notebooks, we need a starting equilibrium. \n",
+    "\n",
+    "This equilibrium will be the initial condition from which the FPDT will evolve the plasma."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:12.288770Z",
+     "iopub.status.busy": "2026-06-21T18:02:12.288665Z",
+     "iopub.status.idle": "2026-06-21T18:02:13.598650Z",
+     "shell.execute_reply": "2026-06-21T18:02:13.598217Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# package\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:13.601480Z",
+     "iopub.status.busy": "2026-06-21T18:02:13.601045Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.500292Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.499907Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Active coils --> built from pickle file.\n",
+      "Passive structures --> built from pickle file.\n",
+      "Limiter --> built from pickle file.\n",
+      "Wall --> built from pickle file.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Magnetic probes --> none provided.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resistance (R) and inductance (M) matrices --> built using actives (and passives if present).\n",
+      "Tokamak built.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Forward static solve SUCCESS. Tolerance 4.81e-09 (vs. requested 1.00e-08) reached in 33/100 iterations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# build machine\n",
+    "from freegsnke import build_machine\n",
+    "tokamak = build_machine.tokamak(\n",
+    "    active_coils_path=f\"../machine_configs/MAST-U/MAST-U_like_active_coils.pickle\",\n",
+    "    passive_coils_path=f\"../machine_configs/MAST-U/MAST-U_like_passive_coils.pickle\",\n",
+    "    limiter_path=f\"../machine_configs/MAST-U/MAST-U_like_limiter.pickle\",\n",
+    "    wall_path=f\"../machine_configs/MAST-U/MAST-U_like_wall.pickle\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# initialise equilibrium\n",
+    "from freegsnke import equilibrium_update\n",
+    "eq = equilibrium_update.Equilibrium(\n",
+    "    tokamak=tokamak,\n",
+    "    Rmin=0.1, Rmax=2.0,   # Radial range\n",
+    "    Zmin=-2.2, Zmax=2.2,  # Vertical range\n",
+    "    nx=65,                # Number of grid points in the radial direction (needs to be of the form (2**n + 1) with n being an integer)\n",
+    "    ny=65,                # Number of grid points in the vertical direction (needs to be of the form (2**n + 1) with n being an integer)\n",
+    ")  \n",
+    "\n",
+    "# initialise profiles\n",
+    "from freegsnke.jtor_update import Lao85\n",
+    "profiles = Lao85(\n",
+    "    eq=eq,                     # equilibrium object\n",
+    "    Ip=7.59e5,                 # plasma current\n",
+    "    fvac=-0.52,                # fvac = rB_{tor}\n",
+    "    alpha=[362685, 17696],     # Lao profiles parameters\n",
+    "    beta=[0.103, 0.753],       # Lao profiles parameters\n",
+    "    alpha_logic=True,\n",
+    "    beta_logic=True,\n",
+    ")\n",
+    "\n",
+    "# set initial coil currents (passive structure currents start at zero here)\n",
+    "coil_currents = np.array([2766.10782056,   193.12768191,  4019.86873871,  4857.42357466,\n",
+    "        -726.99282376, -1696.92521166,   -77.7252396 ,   266.38207493,\n",
+    "         -73.01483716, -4169.86874271, -4518.28147417,   5.2  ])\n",
+    "for i, key in enumerate(tokamak.coil_names[0:12]):\n",
+    "    eq.tokamak.set_coil_current(coil_label=key, current_value=coil_currents[i])\n",
+    "\n",
+    "# initialise the static solver\n",
+    "from freegsnke import GSstaticsolver\n",
+    "GSStaticSolver = GSstaticsolver.NKGSsolver(eq)    \n",
+    "\n",
+    "# solve for the equilbirium\n",
+    "GSStaticSolver.solve(\n",
+    "    eq=eq, \n",
+    "    profiles=profiles, \n",
+    "    constrain=None, \n",
+    "    target_relative_tolerance=1e-8,\n",
+    "    )\n",
+    "\n",
+    "# plot the equilbirium\n",
+    "fig1, ax1 = plt.subplots(1, 1, figsize=(4, 8), dpi=70)\n",
+    "ax1.grid(True, which='both')\n",
+    "eq.plot(axis=ax1, show=False)\n",
+    "eq.tokamak.plot(axis=ax1, show=False)\n",
+    "ax1.set_xlim(0.1, 2.15)\n",
+    "ax1.set_ylim(-2.25, 2.25)\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prepare inputs for the PCS class\n",
+    "\n",
+    "Here, we will set up the inputs (lists and dictionaries) for each of the (internal) controller classes within the virtual PCS (e.g. plasma, shape, virtual circuits). \n",
+    "\n",
+    "We start by defining which coils have which purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.501984Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.501852Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.504067Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.503807Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# COIL NAMES AND SHAPE TARGET NAMES\n",
+    "\n",
+    "# active coils: must match the order they appear in FreeGSNKE machine description\n",
+    "active_coils = ['Solenoid', 'PX', 'D1', 'D2', 'D3', 'Dp', 'D5', 'D6', 'D7', 'P4', 'P5', 'P6']\n",
+    "\n",
+    "# control coils: a subset of the active coils to be used for plasma and shape parameter control (i.e. we exclude vertical control coil P6 here)\n",
+    "ctrl_coils = ['Solenoid', 'PX', 'D1', 'D2', 'D3', 'Dp', 'D5', 'D6', 'D7', 'P4', 'P5']\n",
+    "\n",
+    "# Ohmic coil (for plasma current control) \n",
+    "solenoid_coils=[\"Solenoid\"]\n",
+    "\n",
+    "# vertical control coil\n",
+    "vertical_coils=[\"P6\"]\n",
+    "\n",
+    "# names of the plasma targets (this will be clear later, equal to the number of solenoid coils)\n",
+    "plasma_targets = ['plasma']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All of the following inputs are going to be specified as **waveforms**, i.e. they will be a dicitonary of **times** and **vals**. \n",
+    "\n",
+    "For each array/list of **times** (in seconds), we must specify a corresponding list of list/arrays in **vals**. \n",
+    "\n",
+    "Most waveform quantities (e.g. `*_ref`, `*_ff`, `blend`) will use **linear** interpolation inside the PCS class internally, to enable querying at a given time $t$ within the simulation.\n",
+    "\n",
+    "Some other quantities (e.g. PID gains, virtual circuits, and other arrays), will use **previous-value (or step)** interpolation where the value defined at time `tmin` is used over the interval $ [t_\\mathrm{min},\\, t_\\mathrm{next})$, after which the value defined at `tnext` is applied.\n",
+    "\n",
+    "We will denote which quantity uses which type of interpolation with **linear ** or **step**. \n",
+    "\n",
+    "The following two cells provide an example of how to set these two different waveforms types and what they look like when plotted. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.505391Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.505289Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.627044Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.626735Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/2355852286.py:23: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# waveform dictionary structure (for linearly interpolated quantity)\n",
+    "# e.g. this could be the desired radial position of the X-point over time\n",
+    "waveform = {\n",
+    "    \"times\": np.array([0.0, 0.05, 0.15, 0.35, 0.45, 0.5]),\n",
+    "     \"vals\": np.array([0.57, 0.57, 0.5, 0.5, 0.57, 0.57]),\n",
+    "}\n",
+    "\n",
+    "# plot what it looks like \n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=1,\n",
+    "    ncols=1,\n",
+    "    figsize=(8, 4),\n",
+    "    dpi=80\n",
+    ")\n",
+    "\n",
+    "ax.plot(waveform['times'], waveform['vals'], color='k', linewidth=1, linestyle=\"--\", marker=\"x\", markersize=7, label=\"linearly interpolated waveform\")\n",
+    "\n",
+    "ax.set_xlabel(r\"Shot time [$s$]\")\n",
+    "ax.set_ylabel(\"Scalar quantity [units]\")\n",
+    "ax.grid()\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.628625Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.628524Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.650495Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.650233Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/424721672.py:25: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# waveform dictionary structure (for step interpolated quantity)\n",
+    "# e.g. this could be a proportional PID gain over time\n",
+    "waveform = {\n",
+    "    \"times\": np.array([0.0, 0.15, 0.3, 0.5]),\n",
+    "     \"vals\": np.array([100, 150, 75, 100]),\n",
+    "}\n",
+    "\n",
+    "# plot what it looks like \n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=1,\n",
+    "    ncols=1,\n",
+    "    figsize=(8, 4),\n",
+    "    dpi=80\n",
+    ")\n",
+    "\n",
+    "ax.step(waveform['times'], waveform['vals'], where='post',\n",
+    "        color='k', linewidth=1, linestyle=\"--\", marker=\"x\", markersize=7,\n",
+    "        label=\"step interpolated waveform\")\n",
+    "\n",
+    "ax.set_xlabel(r\"Shot time [$s$]\")\n",
+    "ax.set_ylabel(\"Scalar quantity [units]\")\n",
+    "ax.grid()\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we define each of the controller settings, let us define some global times, i.e. the start and end of the simulation say. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.652132Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.651992Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.653725Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.653513Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# choose some min amd max simulation times\n",
+    "tmin = 0.0\n",
+    "tmax = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we define the desired control settings for the **plasma category**.\n",
+    "\n",
+    "These waveforms govern how the plasma current, $I_p$, is controlled—either via feedback (FB), feedforward (FF), or a combination of both.\n",
+    "\n",
+    "The following quantities must be specified:\n",
+    "\n",
+    "- **`ip_ref`**: Plasma current feedback reference waveform \\[A\\] (linear).\n",
+    "- **`vloop_ff`**: Loop voltage feedforward reference waveform \\[V·s⁻¹\\] (linear).\n",
+    "- **`blend`**: Control blending parameter [dimensionless] (linear):\n",
+    "  - `1` → purely FB control  \n",
+    "  - `0` → purely FF control  \n",
+    "  - values in `(0, 1)` → mixed FB/FF control.\n",
+    "- **`k_prop`**: Proportional gain waveform for the FB PID controller \\[s⁻¹\\] (step).\n",
+    "- **`k_int`**: Integral gain waveform for the FB PID controller \\[s⁻²\\] (step).\n",
+    "- **`k_deriv`**: Derivative gain waveform for the FB PID controller (no units) (step). \n",
+    "- **`M_solenoid`**: Mutual inductance between the plasma and solenoid (required for FF control) \\[V·s·A⁻¹\\] (step).\n",
+    "\n",
+    "In this particular example, we will tell the PCS to hold the plasma current constant at it's starting value. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.655086Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.655003Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.659897Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.659594Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['ip_ref', 'vloop_ff', 'ip_blend', 'k_prop', 'k_int', 'k_deriv', 'M_solenoid'])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# PLASMA CATEGORY DATA\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "plasma_data = {}\n",
+    "\n",
+    "# plasma current feedback (FB) reference waveform \n",
+    "# here we hold the value for the initial equilibrium constant\n",
+    "plasma_data[\"ip_ref\"] = {\n",
+    "    'times': np.array([tmin, tmax]),\n",
+    "    'vals': np.array([eq._profiles.Ip, eq._profiles.Ip])\n",
+    "    }\n",
+    "\n",
+    "# loop voltage feedforward (FF) reference waveform (can specify the desired loop voltage on the plasma)\n",
+    "# (here we don't use a loop voltage as we will use the FB reference waveform above)\n",
+    "plasma_data[\"vloop_ff\"] = {\n",
+    "    'times': np.array([tmin, tmax]),\n",
+    "    'vals': np.array([0, 0])\n",
+    "    }\n",
+    "\n",
+    "# blending waveform: tells controller to use purely FB control (1), purely FF control (0), or a mixture (between 0 and 1)\n",
+    "# we are doing pure FB control here\n",
+    "plasma_data[\"ip_blend\"] = {\n",
+    "    'times': np.array([tmin, tmax]),\n",
+    "    'vals': np.array([1, 1])\n",
+    "    }\n",
+    "\n",
+    "# proportional gain for the FB PID controller\n",
+    "plasma_data[\"k_prop\"] = {\n",
+    "    'times': np.array([tmin]),\n",
+    "    'vals': np.array([-5*4])\n",
+    "    }\n",
+    "\n",
+    "# integral gain for the FB PID controller\n",
+    "plasma_data[\"k_int\"] = {\n",
+    "    'times': np.array([tmin]),\n",
+    "    'vals': np.array([-50*2])\n",
+    "    }\n",
+    "\n",
+    "# derivative gain for the FB PID controller\n",
+    "plasma_data[\"k_deriv\"] = {\n",
+    "    'times': np.array([tmin]),\n",
+    "    'vals': np.array([0])\n",
+    "    }\n",
+    "\n",
+    "# mutual inductance between plasma and solenoid: required for FF control\n",
+    "# not used here as we do not set a loop voltage\n",
+    "plasma_data[\"M_solenoid\"] = {\n",
+    "    \"times\": np.array([0]), \n",
+    "    \"vals\": np.array([1.0])\n",
+    "    }\n",
+    "\n",
+    "plasma_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define the desired control settings for the **shape category**.\n",
+    "\n",
+    "First, we define a function that extracts the relevant shape parameters from the equilibrium object (here referred to as `plasma_descriptors`). In this example, we extract the following quantities:\n",
+    "\n",
+    "- **`Rin`**: Inboard midplane radius.\n",
+    "- **`Rout`**: Outboard midplane radius.\n",
+    "- **`Rx`**: Radial position of the lower X-point.\n",
+    "- **`Zx`**: Vertical position of the lower X-point.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.661370Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.661252Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.664192Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.663979Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# define the descriptors function (it should return an array of values and take in an eq object)\n",
+    "# outputs (\"measurements\") from this function will be passed to the PCS later on during simulation\n",
+    "def plasma_descriptors(eq):\n",
+    "\n",
+    "    # inboard/outboard midplane radii\n",
+    "    RinRout = eq.innerOuterSeparatrix()\n",
+    "\n",
+    "    # find lower X-point\n",
+    "    # define a \"box\" in which to search for the lower X-point\n",
+    "    XPT_BOX = [[0.33, -0.88], [0.95, -1.38]]\n",
+    "\n",
+    "    # mask those points\n",
+    "    xpt_mask = (\n",
+    "        (eq.xpt[:, 0] >= XPT_BOX[0][0])\n",
+    "        & (eq.xpt[:, 0] <= XPT_BOX[1][0])\n",
+    "        & (eq.xpt[:, 1] <= XPT_BOX[0][1])\n",
+    "        & (eq.xpt[:, 1] >= XPT_BOX[1][1])\n",
+    "    )\n",
+    "    xpts = eq.xpt[xpt_mask, 0:2].squeeze()\n",
+    "    if xpts.ndim > 1 and xpts.shape[0] > 1:\n",
+    "        opt = eq.opt[0, 0:2]\n",
+    "        dists = np.linalg.norm(xpts - opt, axis=1)\n",
+    "        idx = np.argmin(dists)  # index of closest point\n",
+    "        Rx, Zx = xpts[idx, :]\n",
+    "    else:\n",
+    "        Rx, Zx = xpts\n",
+    "\n",
+    "    return np.array([RinRout[0], RinRout[1], Rx, Zx])\n",
+    "\n",
+    "# give these descriptors some names for use in the PCS\n",
+    "ctrl_targets = ['Rin','Rout', 'Rx', 'Zx']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we specify the waveforms used to control these shape parameters throughout the simulation.  \n",
+    "\n",
+    "Not all shape parameters need to be defined in units of metres—these are simply illustrative examples.\n",
+    "\n",
+    "For each shape parameter, the following waveforms must be specified:\n",
+    "\n",
+    "- **`ff`**: Feedforward (FF) waveform (linear).  \n",
+    "  Not used in this example, but can be employed to impose a fixed offset on the parameter \\[m\\].\n",
+    "\n",
+    "- **`ref`**: Feedback (FB) reference waveform (linear).  \n",
+    "  These are the desired target values of the parameter over the course of the simulation \\[m\\].\n",
+    "\n",
+    "- **`blend`**: Control blending waveform specifying the relative contribution of FF and FB control [dimensionless](linear).\n",
+    "  - `0` → purely FF control  \n",
+    "  - `1` → purely FB control  \n",
+    "  - values in `(0, 1)` → mixed FF/FB control. \n",
+    "\n",
+    "- **`k_prop`**: Proportional gain waveform for the FB PID controller \\[s⁻¹\\] (step).\n",
+    "\n",
+    "- **`k_int`**: Integral gain waveform for the FB PID controller (not used here) \\[s⁻²\\] (step).\n",
+    "\n",
+    "- **`k_deriv`**: Derivative gain waveform for the FB PID controller (no units) (step). \n",
+    "\n",
+    "- **`damping`**: Damping waveform (not used here) [dimensionless] (step). \n",
+    "\n",
+    "In the following, we tell will tell the controllers to:\n",
+    "\n",
+    "- hold both **`Rin`** and **`Rout`** constant. \n",
+    "- hold **`Rx`** constant for a short period, before ramping down (to increase plasma triangularity), then ramp back up to the original value.\n",
+    "- allow **`Zx`** to be uncontrolled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.665507Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.665411Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.673786Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.673549Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['Rin', 'Rout', 'Rx', 'Zx'])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# SHAPE/DIVERTOR CATEGORY\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "shape_data = {}\n",
+    "\n",
+    "# waveforms for Rin\n",
+    "shape_data[\"Rin\"] = {}\n",
+    "shape_data[\"Rin\"][\"ff\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.0, 0.0])}          \n",
+    "shape_data[\"Rin\"][\"ref\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.28, 0.28])} \n",
+    "shape_data[\"Rin\"][\"blend\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([1.0, 1.0])}\n",
+    "shape_data[\"Rin\"][\"k_prop\"] = {\"times\": np.array([tmin]), \"vals\": np.array([120])}\n",
+    "shape_data[\"Rin\"][\"k_int\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "shape_data[\"Rin\"][\"k_deriv\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "\n",
+    "# waveforms for Rout\n",
+    "shape_data[\"Rout\"] = {}\n",
+    "shape_data[\"Rout\"][\"ff\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.0, 0.0])}        \n",
+    "shape_data[\"Rout\"][\"ref\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([1.35, 1.35])} \n",
+    "shape_data[\"Rout\"][\"blend\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([1.0, 1.0])}\n",
+    "shape_data[\"Rout\"][\"k_prop\"] = {\"times\": np.array([tmin]), \"vals\": np.array([170])}\n",
+    "shape_data[\"Rout\"][\"k_int\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "shape_data[\"Rout\"][\"k_deriv\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "\n",
+    "# waveforms for Rx\n",
+    "shape_data[\"Rx\"] = {}\n",
+    "shape_data[\"Rx\"][\"ff\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.0, 0.0])}       \n",
+    "shape_data[\"Rx\"][\"ref\"] = {\"times\": np.array([tmin, 0.05, 0.15, 0.35, 0.45, tmax]), \"vals\": np.array([0.57, 0.57, 0.5, 0.5, 0.57, 0.57])}  # we vary Rx\n",
+    "shape_data[\"Rx\"][\"blend\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([1.0, 1.0])}\n",
+    "shape_data[\"Rx\"][\"k_prop\"] = {\"times\": np.array([tmin]), \"vals\": np.array([120])}\n",
+    "shape_data[\"Rx\"][\"k_int\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "shape_data[\"Rx\"][\"k_deriv\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "\n",
+    "# waveforms for Zx\n",
+    "shape_data[\"Zx\"] = {}\n",
+    "shape_data[\"Zx\"][\"ff\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.0, 0.0])}         \n",
+    "shape_data[\"Zx\"][\"ref\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([-1.24, -1.24])}   \n",
+    "shape_data[\"Zx\"][\"blend\"] = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.0, 0.0])}\n",
+    "shape_data[\"Zx\"][\"k_prop\"] = {\"times\": np.array([tmin]), \"vals\": np.array([120])}\n",
+    "shape_data[\"Zx\"][\"k_int\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "shape_data[\"Zx\"][\"k_deriv\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.0])}\n",
+    "\n",
+    "shape_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define the schedule of virtual circuits (VCs) in the **virtual circuits category**.\n",
+    "\n",
+    "For each shape parameter in the **shape category**, a VC is required to map the discrepancy between the target value (from the shape controller) and the measured value (from the equilibrium) to requests for the poloidal field (PF) coil currents. The VCs used here were obtained using the procedure described in the example notebook on VC construction. Recall that VCs are defined with units \\[m/A\\].\n",
+    "\n",
+    "Each VC is an array with length equal to the number of `ctrl_coils`, with entries ordered consistently with that list. When specified in the waveform dictionary, VCs are **previous-value interpolated** by the PCS class. For example, for the `Rin` controller, the VC defined at time `tmin` is used over the interval $ [t_\\mathrm{min},\\, t_\\mathrm{max})$, after which the VC defined at `tmax` is applied. Note here that we use only one VC for each shape parameter as the shape changes are not that significant. If more complex shape changes are required, then more VCs (linearised around the expected plasma shape), will be required. \n",
+    "\n",
+    "Note that the first entry of each shape-parameter VC is zero. This ensures that the solenoid does not contribute to shape control and is reserved exclusively for plasma current, $I_p$, control.\n",
+    "\n",
+    "In addition to the shape VCs, a final VC is defined for the **plasma category**. This VC maps the requested change in $I_p$ from the plasma controller to PF coil current requests (well in this case, only a request to the solenoid).\n",
+    "\n",
+    "Finally, optional pre-programmed feedforward (FF) requests for the PF coil currents may be specified. These allow the coil currents to be set directly if desired. In this example, no such FF requests are used, and the coil currents are driven purely via feedback control.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.675074Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.674993Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.717206Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.716895Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['Rin', 'Rout', 'Rx', 'Zx', 'plasma', 'coil_order', 'Solenoid_ref', 'PX_ref', 'D1_ref', 'D2_ref', 'D3_ref', 'Dp_ref', 'D5_ref', 'D6_ref', 'D7_ref', 'P4_ref', 'P5_ref'])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# VIRTUAL CIRCUITS CATEGORY\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "circuits_data = {}\n",
+    "\n",
+    "circuits_data[\"Rin\"] = {\n",
+    "    \"times\": np.array([tmin]), \n",
+    "    \"vals\": [\n",
+    "        np.array([0, 3.1394e+04,  8.5990e+03, -8.8300e+02, -1.2460e+03, -6.6690e+03, 1.2660e+03,  2.9770e+03,  3.5350e+03,  8.3110e+03, -7.8520e+03]),\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "circuits_data[\"Rout\"] = {\n",
+    "    \"times\": np.array([tmin]), \n",
+    "    \"vals\": [\n",
+    "        np.array([0, -9.9700e+02,  1.1790e+03,  3.9700e+02, -2.0000e+02, -1.8970e+03, -5.5500e+02, -2.2640e+03, -1.5860e+03, -1.9750e+03,  5.5800e+03]),\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "circuits_data[\"Rx\"] = {\n",
+    "    \"times\": np.array([tmin]), \n",
+    "    \"vals\": [\n",
+    "        np.array([0, -3.0021e+04,  3.3980e+03,  8.6900e+03,  5.8310e+03,  1.5858e+04, 2.4000e+01, -1.2100e+02, -2.2160e+03, -9.5290e+03,  1.3570e+03]),\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "circuits_data[\"Zx\"] = {\n",
+    "    \"times\": np.array([tmin]), \n",
+    "    \"vals\": [\n",
+    "        np.array([0, 3.7670e+03,  2.0328e+04,  1.0562e+04,  4.2560e+03,  2.2600e+03, -2.0450e+03, -5.5680e+03, -5.3160e+03, -9.8440e+03,  3.3750e+03]),\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "circuits_data[\"plasma\"] = {\n",
+    "    \"times\": np.array([tmin]), \n",
+    "    \"vals\": [\n",
+    "        np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "# store the coil order for future reference\n",
+    "circuits_data[\"coil_order\"] = ctrl_coils\n",
+    "\n",
+    "# define any feedforward coil current drives on each control coil (no drives used here)\n",
+    "zeros_dict = {\"times\": np.array([tmin, tmax]), \"vals\": np.array([0.0, 0.0])}\n",
+    "for coil in ctrl_coils: # linearly interpolated\n",
+    "    circuits_data[coil+\"_ref\"] = zeros_dict\n",
+    "\n",
+    "circuits_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define the inputs for the **systems category**.\n",
+    "\n",
+    "This controller specifies operational limits for the coils listed in `ctrl_coils`, including:\n",
+    "\n",
+    "- **`min_coil_curr_lims`**: Minimum allowable coil currents \\[A\\] (step).\n",
+    "- **`max_coil_curr_lims`**: Maximum allowable coil currents \\[A\\] (step).\n",
+    "- **`max_coil_curr_ramp_lims`**: Maximum allowable coil current ramp rates \\[A·s⁻¹\\] (step).\n",
+    "\n",
+    "There is also the option to define feedforward (FF) perturbations (linear) to the control coil currents—similar to the FF drives available in the **virtual circuits category**. These are not used here.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.718642Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.718557Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.721824Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.721559Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['min_coil_curr_lims', 'max_coil_curr_lims', 'max_coil_curr_ramp_lims', 'Solenoid_pert', 'PX_pert', 'D1_pert', 'D2_pert', 'D3_pert', 'Dp_pert', 'D5_pert', 'D6_pert', 'D7_pert', 'P4_pert', 'P5_pert'])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# SYSTEMS CATEGORY\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "systems_data = {}\n",
+    "\n",
+    "# define the min coil current limits and ramp rate limits\n",
+    "systems_data[\"min_coil_curr_lims\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [np.array([-10000, -7000, -9000, -9000, -9000, -9000, -9000, -9000, -9000, -10000, -10000])],\n",
+    "    }\n",
+    "\n",
+    "# define the max coil current limits\n",
+    "systems_data[\"max_coil_curr_lims\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [np.array([10000, 7000, 9000, 9000, 9000, 9000, 9000, 9000, 9000, 0, 0])],\n",
+    "    }\n",
+    "\n",
+    "# define the max ramp rate limits for the coils\n",
+    "systems_data[\"max_coil_curr_ramp_lims\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [1e12*np.ones(len(ctrl_coils))],\n",
+    "    }\n",
+    "\n",
+    "# define the control coil current perturbations\n",
+    "for name in ctrl_coils: # linearly interpolated\n",
+    "    systems_data[name+\"_pert\"] = zeros_dict\n",
+    "\n",
+    "systems_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define the inputs for the **PF category**.\n",
+    "\n",
+    "This category specifies the electrical properties, gains, and operational limits of the poloidal field (PF) coils. These inputs are used by the virtual PCS to convert coil current requests into physically consistent voltage commands.\n",
+    "\n",
+    "The following quantities must be provided:\n",
+    "\n",
+    "- **`R_matrix`**: Coil resistance array for the PF coils \\[Ω\\] (step).  \n",
+    "  Defined as a time-dependent waveform and restricted to the coils listed in `ctrl_coils`.\n",
+    "\n",
+    "- **`M_FF_matrix`**: Coil mutual inductance matrix used in feedforward (FF) terms \\[Vs/A\\] (step).  \n",
+    "  This accounts for inductive coupling between PF coils when computing FF voltage requests.\n",
+    "\n",
+    "- **`M_FB_matrix`**: Coil mutual inductance matrix used in feedback (FB) terms \\[Vs/A\\] (step).\n",
+    "  This accounts for inductive coupling between PF coils when computing FF voltage requests. Often it is identical to `M_FF_matrix`, but is provided separately for flexibility.\n",
+    "\n",
+    "- **`coil_gains`**: Feedback gain applied to each PF coil \\[s\\] (step).  \n",
+    "  These gains scale the feedback voltage contributions on a per-coil basis.\n",
+    "\n",
+    "- **`coil_voltage_lims`**: Maximum allowable voltages for each PF coil \\[V\\] (step).  \n",
+    "  These limits are enforced by the PCS when generating coil voltage commands.\n",
+    "\n",
+    "- **`coil_voltage_slew_lims`**: Maximum allowable voltage ramp rates for each PF coil \\[V·s⁻¹\\] (step).  \n",
+    "  In this example, very large values are used, effectively disabling slew-rate limiting.\n",
+    "\n",
+    "All quantities are defined as time-dependent waveforms, even when constant, to allow future extension to time-varying PF system parameters.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.723113Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.723035Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.726426Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.726182Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['R_matrix', 'M_FF_matrix', 'M_FB_matrix', 'coil_gains', 'coil_voltage_lims', 'coil_voltage_slew_lims'])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# PF CATEGORY\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "pf_data = {}\n",
+    "\n",
+    "# coil resistances\n",
+    "pf_data[\"R_matrix\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [tokamak.coil_resist[0:11]],\n",
+    "    }\n",
+    "\n",
+    "# coil mutual inductances (on feedforward terms)\n",
+    "pf_data[\"M_FF_matrix\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [tokamak.coil_self_ind[0:11,0:11]],\n",
+    "    }\n",
+    "\n",
+    "# coil mutual inductances (on feedback terms)\n",
+    "pf_data[\"M_FB_matrix\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [tokamak.coil_self_ind[0:11,0:11]],\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "# gains on the coils (for feedback term)\n",
+    "pf_data[\"coil_gains\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [0.015*np.ones(len(ctrl_coils))],\n",
+    "    }\n",
+    "\n",
+    "# limits on voltages in the coils\n",
+    "pf_data[\"coil_voltage_lims\"] = {\n",
+    "    \"times\": np.array([0.0]),\n",
+    "    'vals': [[2000,  750,  750,  750,  750,  750,  750,  750,  750,  750,  750]],\n",
+    "     } \n",
+    "\n",
+    "# limits on voltage ramp rates in the coils (we set no limits here)\n",
+    "pf_data[\"coil_voltage_slew_lims\"] = {\n",
+    "    'times': [0.0],\n",
+    "    'vals': [1e12*np.ones(len(ctrl_coils))],\n",
+    "    }\n",
+    "\n",
+    "pf_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define the inputs for the **vertical category**.\n",
+    "\n",
+    "This category configures the feedback controller responsible for stabilising and controlling the vertical position of the plasma column using the vertical control coil (here the `P6` coil). \n",
+    "\n",
+    "The following quantities must be specified:\n",
+    "\n",
+    "- **`z_ref`**: Plasma vertical position reference waveform \\[m\\] (linear).  \n",
+    "  This defines the desired vertical position of the plasma as a function of time.\n",
+    "\n",
+    "- **`k_prop`**: Proportional gain waveform for the vertical position feedback controller \\[s⁻¹\\] (step).  \n",
+    "  This gain determines the strength of the restoring force in response to vertical displacement.\n",
+    "\n",
+    "- **`k_deriv`**: Derivative gain waveform for the vertical position feedback controller \\[s⁻²\\] (step).\n",
+    "  This term provides damping by responding to the rate of change of the vertical position.\n",
+    "\n",
+    "All inputs are defined as time-dependent waveforms, allowing for time-varying vertical control behaviour if required.\n",
+    "\n",
+    "In this example, we steadily increase the vertical position to before holding it constant thereafter. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.727617Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.727538Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.730397Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.730205Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['z_ref', 'k_prop', 'k_deriv'])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# VERTICAL CATEGORY DATA\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "vertical_data = {}\n",
+    "\n",
+    "# plasma vertical position reference\n",
+    "vertical_data[\"z_ref\"] = {\"times\": np.array([tmin, tmin+0.25, tmax]), \"vals\": np.array([0.0, 0.01, 0.01])}\n",
+    "\n",
+    "# proportional gain\n",
+    "vertical_data[\"k_prop\"] = {\"times\": np.array([tmin]), \"vals\": np.array([0.025])}\n",
+    "\n",
+    "# derivative gain\n",
+    "vertical_data[\"k_deriv\"] = {\"times\": np.array([tmin]), \"vals\": np.array([5e-7])}\n",
+    "\n",
+    "vertical_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we define the inputs for the **coil activations category**.\n",
+    "\n",
+    "This category specifies when each active poloidal field (PF) coil is enabled or disabled during the simulation. Coil activations are represented as time-dependent waveforms and are applied on a per-coil basis.\n",
+    "\n",
+    "For each coil listed in `active_coils`, the following entry is defined:\n",
+    "\n",
+    "- **`<coil_name>_activation`**: Coil activation waveform (step).  \n",
+    "  A value of:\n",
+    "  - `1.0` indicates that the coil is active and available to the PCS.\n",
+    "  - `0.0` indicates that the coil is inactive and excluded from PCS.\n",
+    "\n",
+    "In this example, all coils are activated for the entire simulation interval $[t_\\mathrm{min},\\, t_\\mathrm{max}]$, using constant activation waveforms. This structure allows coils to be selectively enabled or disabled at different times in more advanced scenarios.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.731618Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.731531Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.733969Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.733713Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['Solenoid_activation', 'PX_activation', 'D1_activation', 'D2_activation', 'D3_activation', 'Dp_activation', 'D5_activation', 'D6_activation', 'D7_activation', 'P4_activation', 'P5_activation', 'P6_activation'])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# COIL ACTIVATIONS CATEGORY\n",
+    "\n",
+    "# build the dictionary which will be passed to the virtual PCS (all keys below are required)\n",
+    "coil_activation_data = {}\n",
+    "\n",
+    "# coil activation times\n",
+    "default_coil_dict = {\"times\": np.array([tmin]), \"vals\": np.array([1.0])}\n",
+    "for name in active_coils:\n",
+    "    coil_activation_data[name+\"_activation\"] = default_coil_dict\n",
+    "\n",
+    "coil_activation_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialise the virtual PCS class\n",
+    "\n",
+    "Now that the inputs have been prepared we can initialise the class and use in-built functions to view or plot the waveform data in each control category. This will build internal classes for each of the above listed controllers. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.735464Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.735353Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.804758Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.804478Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# FIRE UP THE PLASMA CONTROL SYSTEM\n",
+    "from freegsnke.control_loop.pcs import PlasmaControlSystem\n",
+    "\n",
+    "PCS = PlasmaControlSystem(\n",
+    "    plasma_data=plasma_data,\n",
+    "    shape_data=shape_data,\n",
+    "    shape_control_mode=\"PID\",\n",
+    "    circuits_data=circuits_data,\n",
+    "    systems_data=systems_data,\n",
+    "    pf_data=pf_data,\n",
+    "    vertical_data=vertical_data,\n",
+    "    coil_activation_data=coil_activation_data,\n",
+    "    active_coils=active_coils,\n",
+    "    ctrl_coils=ctrl_coils,\n",
+    "    solenoid_coils=solenoid_coils,\n",
+    "    vertical_coils=vertical_coils,\n",
+    "    ctrl_targets=ctrl_targets,\n",
+    "    plasma_target=plasma_targets,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.806257Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.806165Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.808801Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.808568Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ip_ref': {'times': array([0. , 0.5]), 'vals': array([759000., 759000.])},\n",
+       " 'vloop_ff': {'times': array([0. , 0.5]), 'vals': array([0, 0])},\n",
+       " 'ip_blend': {'times': array([0. , 0.5]), 'vals': array([1, 1])},\n",
+       " 'k_prop': {'times': array([0.]), 'vals': array([-20])},\n",
+       " 'k_int': {'times': array([0.]), 'vals': array([-100])},\n",
+       " 'k_deriv': {'times': array([0.]), 'vals': array([0])},\n",
+       " 'M_solenoid': {'times': array([0]), 'vals': array([1.])}}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# each controller should contain a copy of the waveform dictionaries internally\n",
+    "PCS.PlasmaController.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.810023Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.809937Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.812171Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.811934Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ip_ref': <scipy.interpolate._fitpack2.InterpolatedUnivariateSpline at 0x3138c19f0>,\n",
+       " 'vloop_ff': <scipy.interpolate._fitpack2.InterpolatedUnivariateSpline at 0x3138c2f20>,\n",
+       " 'ip_blend': <scipy.interpolate._fitpack2.InterpolatedUnivariateSpline at 0x313674c70>,\n",
+       " 'k_prop': <scipy.interpolate._interpolate.interp1d at 0x11fe687c0>,\n",
+       " 'k_int': <scipy.interpolate._interpolate.interp1d at 0x11fe6aca0>,\n",
+       " 'k_deriv': <scipy.interpolate._interpolate.interp1d at 0x11fe6ab60>,\n",
+       " 'M_solenoid': <scipy.interpolate._interpolate.interp1d at 0x11fe6ab10>}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# it will also contain a dictionary of functions that has linearly (or previous value) interpolated the various waveforms\n",
+    "PCS.PlasmaController.interpolants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.813352Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.813270Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.814792Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.814583Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# # it should also be possible to plot the data (uncomment following cell)\n",
+    "# # green shading indiciates times that FB control is ON, yellow that FF is ON, a mix that both are ON, and white that there is no control\n",
+    "# PCS.PlasmaController.plot_data(tmin=tmin, tmax=tmax)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.815938Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.815857Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.817727Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.817510Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<bound method PlasmaController.run_control of <freegsnke.control_loop.plasma_category.PlasmaController object at 0x3138c2890>>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# the \"run_control\" method will be used internally later on but can also be called explicitly if required\n",
+    "PCS.PlasmaController.run_control"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, suppose you wish to modify the shot setup data after initialising the PCS class. \n",
+    "\n",
+    "To do this, simply edit the waveforms required directly in the `.data` attribute of the controller of interest and then call `.update_interpolants()`. This has to be done to ensure that the controller refreshes any stale interpolants from a prior initialisation.\n",
+    "\n",
+    "Uncomment the code below to see how it works for an example in the `ShapeController`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.818984Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.818905Z",
+     "iopub.status.idle": "2026-06-21T18:02:22.820444Z",
+     "shell.execute_reply": "2026-06-21T18:02:22.820223Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# # update the data entry with your new waveform\n",
+    "# new_waveform = {\"times\": np.array([tmin, 0.05, 0.15, 0.35, 0.45, tmax]), \"vals\": np.array([0.28, 0.28, 0.30, 0.30, 0.28, 0.28])}  # we vary Rin\n",
+    "# PCS.ShapeController.data[\"Rin\"][\"ref\"] = new_waveform\n",
+    "\n",
+    "# # call the update function to refresh inteprolants (essential)\n",
+    "# PCS.ShapeController.update_interpolants()\n",
+    "\n",
+    "# # plot to see new waveform\n",
+    "# PCS.ShapeController.plot_data(targ=\"Rin\", tmin=tmin, tmax=tmax)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialise the nonlinear solver object\n",
+    "Now choose the desired settings for the nonlinear solver object - recall the prior example notebook on this. \n",
+    "\n",
+    "The simulation timestep will be modified later on but be sure to choose a value that is 5-10x smaller than the vertical instability timescale returned in the output of this cell - this keeps the simulation numerically stable. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:22.821668Z",
+     "iopub.status.busy": "2026-06-21T18:02:22.821590Z",
+     "iopub.status.idle": "2026-06-21T18:02:41.438561Z",
+     "shell.execute_reply": "2026-06-21T18:02:41.437933Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----\n",
+      "Checking that the provided 'eq' and 'profiles' are a GS solution...\n",
+      "Forward static solve SUCCESS. Tolerance 4.81e-09 (vs. requested 1.00e-08) reached in 0/100 iterations.\n",
+      "-----\n",
+      "Instantiating nonlinear solver objects...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\n",
+      "-----\n",
+      "Identifying mode selection criteria...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      'fix_n_vessel_modes' option selected --> passive structure modes that couple most to the strongest passive structure mode are being selected.\n",
+      "-----\n",
+      "Initial mode selection:\n",
+      "   Active coils\n",
+      "      total selected = 12 (out of 12)\n",
+      "   Passive structures\n",
+      "      30 selected using 'fix_n_vessel_modes'\n",
+      "   Total number of modes = 42 (12 active coils + 30 passive structures)\n",
+      "      (Note: some additional modes may be removed after Jacobian calculation if 'mode_removal=True')\n",
+      "-----\n",
+      "Building the 1513 x 43 Jacobian (dIy/dI) of plasma current density (inside the LCFS) with respect to all metal currents and the total plasma current.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building the 1513 x 4 Jacobian (dIy/dtheta) of plasma current density (inside the LCFS) with respect to all plasma current density profile parameters within Jtor.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Built the 4 x 43 Jacobian (ds/dI) of plasma descriptors with respect to all metal currents and the total plasma current.\n",
+      "Built the 4 x 4 Jacobian (ds/dtheta) of plasma descriptors with respect to all plasma current density profile parameters within Jtor.\n",
+      "-----\n",
+      "Stability paramters:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Deformable plasma metrics:\n",
+      "      Growth rate = [27.20271834] [1/s]\n",
+      "      Instability timescale = [0.03676103] [s]\n",
+      "      Inductive stability margin = [0.75454395+0.j]\n",
+      "   Rigid plasma metrics:\n",
+      "      Leuer parameter (ratio of stabilsing to de-stabilising force gradients):\n",
+      "          between all metals and all metals = 2.0951036090628343\n",
+      "          between all metals and active metals = 2.0951036090628343\n",
+      "          between passive metals and active metals = 2.0950856699675153\n",
+      "-----\n",
+      "Evolutive solver timestep:\n",
+      "      Solver timestep 'dt_step' has been set to 0.0005 as requested.\n",
+      "      Ensure it is smaller than the growth rate else you may find numerical instability in any subsequent evoltuive simulations!\n",
+      "-----\n"
+     ]
+    }
+   ],
+   "source": [
+    "from freegsnke import nonlinear_solve\n",
+    "\n",
+    "stepping = nonlinear_solve.nl_solver(\n",
+    "    eq=eq, \n",
+    "    profiles=profiles, \n",
+    "    GSStaticSolver=GSStaticSolver,\n",
+    "    full_timestep=5e-4, \n",
+    "    plasma_resistivity=1e-7,\n",
+    "    fix_n_vessel_modes=30,               \n",
+    "    plasma_descriptor_function=plasma_descriptors,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define FPDT simulation parameters\n",
+    "\n",
+    "Next set the key simulation parameters for the FPDT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:41.441586Z",
+     "iopub.status.busy": "2026-06-21T18:02:41.441211Z",
+     "iopub.status.idle": "2026-06-21T18:02:41.480941Z",
+     "shell.execute_reply": "2026-06-21T18:02:41.480315Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# FPDT SETUP\n",
+    "\n",
+    "# number of simulation time steps\n",
+    "n = 500\n",
+    "\n",
+    "# simulation time step size (must be smaller than the vertical instability timescale)\n",
+    "dt = 1e-3\n",
+    "\n",
+    "# PCS time step (this must be whole fraction of the simulation time step)\n",
+    "# it governs the frequency at which the PCS is called\n",
+    "dt_PCS = 1e-4\n",
+    "\n",
+    "# starting time (leave as it is)\n",
+    "tmin = 0.0\n",
+    "\n",
+    "# automatically calculates time array and sets time step in solver object\n",
+    "stepping.dt_step = dt\n",
+    "t_end = tmin + n*dt\n",
+    "times = np.arange(tmin, t_end, dt)\n",
+    "\n",
+    "# (re-)initialise the dynamic solver with the initial eq and profiles\n",
+    "stepping.initialize_from_ICs(eq, profiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before moving forward, we set up the profile evolution targets. Example 11 keeps the Lao `alpha` and `beta` coefficients constant directly. In this variant, we instead calculate the initial-condition `beta_p` and `li` from the toy equilibrium and keep those physical quantities constant.\n",
+    "\n",
+    "The evolutive solver still uses `Lao85` profiles internally. When the time loop passes `profiles_parameters={\"betap\": ..., \"li\": ...}`, the solver converts these physical targets into the Lao `alpha` and `beta` coefficients needed by the linearised profile-response model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:41.484054Z",
+     "iopub.status.busy": "2026-06-21T18:02:41.483811Z",
+     "iopub.status.idle": "2026-06-21T18:02:42.167116Z",
+     "shell.execute_reply": "2026-06-21T18:02:42.166785Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constant beta_p target = 0.2983\n",
+      "Constant li target     = 0.6694\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PROFILE EVOLUTION TARGETS\n",
+    "\n",
+    "# There is no EFIT reconstruction in this toy FPDT example. Use the solved\n",
+    "# initial condition to define constant physical profile targets.\n",
+    "initial_betap = eq.poloidalBeta1()\n",
+    "initial_li = eq.internalInductance2()\n",
+    "\n",
+    "profile_betap_ref = {\n",
+    "    \"times\": np.array([tmin, t_end]),\n",
+    "    \"vals\": np.array([initial_betap, initial_betap]),\n",
+    "}\n",
+    "profile_li_ref = {\n",
+    "    \"times\": np.array([tmin, t_end]),\n",
+    "    \"vals\": np.array([initial_li, initial_li]),\n",
+    "}\n",
+    "\n",
+    "profile_constraint_options = {\n",
+    "    \"li_method\": \"internalInductance2\",\n",
+    "    \"target_relative_tolerance\": 1e-7,\n",
+    "    \"max_solving_iterations\": 40,\n",
+    "    \"optimizer_kwargs\": {\"max_nfev\": 2},\n",
+    "    \"regularization_weight\": 1e-6,\n",
+    "    \"use_metric_jacobian\": True,\n",
+    "    \"reuse_metric_jacobian\": True,\n",
+    "    \"linearized_metric_update\": True,\n",
+    "    \"linearized_metric_regularization\": 1e-8,\n",
+    "    \"linearized_metric_step_fraction\": 0.25,\n",
+    "}\n",
+    "\n",
+    "print(f\"Constant beta_p target = {initial_betap:.4g}\")\n",
+    "print(f\"Constant li target     = {initial_li:.4g}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### FPDT Simulation\n",
+    "\n",
+    "In the following cell, we initialise lists/arrays to store any equilbirium related data we wish to view after the simulation. See the FreeGSNKE example notebook (example03 - extracting_equilibrium_quantites) for a list of these and how to extract them. \n",
+    "\n",
+    "Note that some quantities can be computationally costly to extract and have not been optimised for speed yet!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:42.168794Z",
+     "iopub.status.busy": "2026-06-21T18:02:42.168676Z",
+     "iopub.status.idle": "2026-06-21T18:02:42.794768Z",
+     "shell.execute_reply": "2026-06-21T18:02:42.794391Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# equilibrium-related data storage\n",
+    "dynamic_psi = np.zeros((stepping.eq1.psi().shape[0], stepping.eq1.psi().shape[1], len(times)))    # total poloidal flux\n",
+    "dynamic_limiter_flag = np.zeros(len(times))                                                       # flag if plasma is limited\n",
+    "dynamic_psi_boundary = np.zeros(len(times))                                                       # poloidal flux on plasma boundary\n",
+    "dynamic_xpts = []                                                                                 # list of X-point locations and associated poloidal flux\n",
+    "dynamic_opts = []                                                                                 # list of O-point locations and associated poloidal flux\n",
+    "dynamic_currents = np.zeros((len(stepping.currents_vec[:-1]),len(times)))                         # PF coil and vessel eigenmode currents \n",
+    "dynamic_ip = np.zeros(len(times))                                                                 # total plasma current\n",
+    "dynamic_shape_targets = np.zeros((len(ctrl_targets),len(times)))                                  # shape parameters\n",
+    "dynamic_timings = np.zeros(len(times))                                                            # solver runtime at each time step\n",
+    "dynamic_triangularity = np.zeros(len(times))                                                      # plasma triangularity\n",
+    "dynamic_betap = np.zeros(len(times))                                                             # achieved poloidal beta\n",
+    "dynamic_li = np.zeros(len(times))                                                                # achieved internal inductance\n",
+    "profile_betap_target = np.zeros(len(times))                                                      # requested poloidal beta\n",
+    "profile_li_target = np.zeros(len(times))                                                         # requested internal inductance\n",
+    "\n",
+    "# PCS-related data storage\n",
+    "V_approved = np.zeros((len(ctrl_coils)+1,len(times)))                                             # final PF coil voltages from the PCS class (passed into solver)\n",
+    "ip_hist = np.zeros(len(times))                                                                    # integral term feeding into Plasma Category PID FB controller (at prior time step)\n",
+    "ip_err = np.zeros(len(times))                                                                     # (error) for derivative term feeding into Plasma Category PID FB controller (at prior time step)\n",
+    "T_err = np.zeros((len(ctrl_targets),len(times)))                                                  # proportional term feeding into Shape Category PID FB controller (at prior time step)\n",
+    "T_hist = np.zeros((len(ctrl_targets),len(times)))                                                 # integral term feeding into Shape Category PID FB controller (at prior time step)\n",
+    "I_approved = np.zeros((len(ctrl_coils),len(times)))                                               # approved PF coil currents from prior time step feeding into System Category\n",
+    "coil_resists = np.zeros((len(active_coils),len(times)))                                           # PF coil resistances (to tell solver if a coil is switched on or off)\n",
+    "z_current = []                                                                                    # vertical position of the plasma (average jtor position)\n",
+    "dynamic_jtor_norm = []                                                                            # norm change in jtor between time steps (used to trigger relinearisation)\n",
+    "threshold = None                                                                                  # relative jtor threshold (since last linearisation) above which relinearisation is triggered (here not used)\n",
+    "\n",
+    "# extract any initial values from the initial equilibrium\n",
+    "dynamic_psi[:,:,0] = stepping.eq1.psi()\n",
+    "dynamic_limiter_flag[0] = stepping.eq1._profiles.flag_limiter\n",
+    "dynamic_psi_boundary[0] = stepping.eq1._profiles.psi_bndry\n",
+    "dynamic_xpts.append(stepping.eq1.xpt)\n",
+    "dynamic_opts.append(stepping.eq1.opt)\n",
+    "dynamic_currents[:,0] = stepping.currents_vec[:-1].copy()\n",
+    "dynamic_ip[0] = stepping.profiles1.Ip\n",
+    "dynamic_shape_targets[:,0] = plasma_descriptors(eq=stepping.eq1)\n",
+    "dynamic_triangularity[0] = eq.triangularity()\n",
+    "dynamic_betap[0] = stepping.eq1.poloidalBeta1()\n",
+    "dynamic_li[0] = stepping.eq1.internalInductance2()\n",
+    "profile_betap_target[0] = np.interp(times[0], profile_betap_ref[\"times\"], profile_betap_ref[\"vals\"])\n",
+    "profile_li_target[0] = np.interp(times[0], profile_li_ref[\"times\"], profile_li_ref[\"vals\"])\n",
+    "z_current.append(stepping.eq1.Zcurrent())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before running the following cell (which takes a few minutes), be sure to familiarise yourself with all of the steps.\n",
+    "\n",
+    "During each time step:\n",
+    "\n",
+    "1. The primary method in the `PCS` class, `calculate_ctrl_voltages`, is called. Using “measurements” from the current equilibrium (plasma current, coil currents, and shape parameters), it computes the voltages to be applied to the evolutive solver, as well as the coil resistances (to determine whether any coils are switched off). These voltages enact the plasma control.\n",
+    "\n",
+    "2. The plasma current density profile targets are placed into a dictionary for use by the evolutive solver. In this example, the targets are constant `betap` and `li` values calculated from the toy initial condition; the solver converts them to the Lao `alpha` and `beta` coefficients required by the linearised profile-response model.\n",
+    "\n",
+    "3. The evolutive solver is then called using these parameters (along with additional ones). At this stage, several choices can be made:\n",
+    "   - Specify a time-dependent plasma resistivity (usually required for resimulation of prior discharges).\n",
+    "   - Select, via `linear_only`, either a linear or fully nonlinear solution of the circuit, plasma, and Grad–Shafranov equations.\n",
+    "   - Set a relinearisation threshold when using linear mode (see example notebook 05c).\n",
+    "   - Choose not to solve the Grad–Shafranov equation fully (whenusing linear mode), but instead solve only for the shape parameters specified in `plasma_descriptors` (see example notebooks 05b and 05c).\n",
+    "\n",
+    "4. The required data are stored following successful completion of the time step.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:02:42.796573Z",
+     "iopub.status.busy": "2026-06-21T18:02:42.796451Z",
+     "iopub.status.idle": "2026-06-21T18:16:54.577726Z",
+     "shell.execute_reply": "2026-06-21T18:16:54.577428Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----\n",
+      "t = 0.0s (step 1/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.277  1.347  0.567 -1.245]\n",
+      "      Z position = 0.00034 [m]\n",
+      "      beta_p/li = 0.2982 / 0.673\n",
+      "-----\n",
+      "t = 0.001s (step 2/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.348  0.568 -1.246]\n",
+      "      Z position = 8e-05 [m]\n",
+      "      beta_p/li = 0.3012 / 0.6697\n",
+      "-----\n",
+      "t = 0.002s (step 3/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.347  0.568 -1.246]\n",
+      "      Z position = 0.00018 [m]\n",
+      "      beta_p/li = 0.3009 / 0.669\n",
+      "-----\n",
+      "t = 0.003s (step 4/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.347  0.568 -1.246]\n",
+      "      Z position = 0.00027 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6684\n",
+      "-----\n",
+      "t = 0.004s (step 5/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.346  0.568 -1.245]\n",
+      "      Z position = 0.00031 [m]\n",
+      "      beta_p/li = 0.2985 / 0.6687\n",
+      "-----\n",
+      "t = 0.005s (step 6/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.346  0.568 -1.245]\n",
+      "      Z position = 0.00036 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6698\n",
+      "-----\n",
+      "t = 0.006s (step 7/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.347  0.568 -1.245]\n",
+      "      Z position = 0.00034 [m]\n",
+      "      beta_p/li = 0.2985 / 0.6674\n",
+      "-----\n",
+      "t = 0.007s (step 8/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.346  0.568 -1.244]\n",
+      "      Z position = 0.00045 [m]\n",
+      "      beta_p/li = 0.2968 / 0.6703\n",
+      "-----\n",
+      "t = 0.008s (step 9/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.347  0.568 -1.245]\n",
+      "      Z position = 0.00041 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6676\n",
+      "-----\n",
+      "t = 0.009s (step 10/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.347  0.569 -1.244]\n",
+      "      Z position = 0.00051 [m]\n",
+      "      beta_p/li = 0.2968 / 0.6697\n",
+      "-----\n",
+      "t = 0.01s (step 11/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.348  0.569 -1.244]\n",
+      "      Z position = 0.00048 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6686\n",
+      "-----\n",
+      "t = 0.011s (step 12/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.348  0.569 -1.244]\n",
+      "      Z position = 0.00055 [m]\n",
+      "      beta_p/li = 0.2974 / 0.669\n",
+      "-----\n",
+      "t = 0.012s (step 13/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.569 -1.244]\n",
+      "      Z position = 0.00058 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6694\n",
+      "-----\n",
+      "t = 0.013s (step 14/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.57  -1.244]\n",
+      "      Z position = 0.00061 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6706\n",
+      "-----\n",
+      "t = 0.014s (step 15/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.57  -1.244]\n",
+      "      Z position = 0.00062 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6728\n",
+      "-----\n",
+      "t = 0.015s (step 16/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.571 -1.245]\n",
+      "      Z position = 0.0006 [m]\n",
+      "      beta_p/li = 0.3024 / 0.6706\n",
+      "-----\n",
+      "t = 0.016s (step 17/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.571 -1.245]\n",
+      "      Z position = 0.00066 [m]\n",
+      "      beta_p/li = 0.3023 / 0.6692\n",
+      "-----\n",
+      "t = 0.017s (step 18/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.571 -1.245]\n",
+      "      Z position = 0.00075 [m]\n",
+      "      beta_p/li = 0.3008 / 0.6685\n",
+      "-----\n",
+      "t = 0.018s (step 19/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.571 -1.245]\n",
+      "      Z position = 0.00079 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6678\n",
+      "-----\n",
+      "t = 0.019s (step 20/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.571 -1.244]\n",
+      "      Z position = 0.00085 [m]\n",
+      "      beta_p/li = 0.2976 / 0.6697\n",
+      "-----\n",
+      "t = 0.02s (step 21/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.571 -1.244]\n",
+      "      Z position = 0.00082 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6689\n",
+      "-----\n",
+      "t = 0.021s (step 22/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.571 -1.244]\n",
+      "      Z position = 0.00088 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6691\n",
+      "-----\n",
+      "t = 0.022s (step 23/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 757.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.571 -1.244]\n",
+      "      Z position = 0.00092 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6711\n",
+      "-----\n",
+      "t = 0.023s (step 24/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.572 -1.244]\n",
+      "      Z position = 0.00093 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6701\n",
+      "-----\n",
+      "t = 0.024s (step 25/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.572 -1.245]\n",
+      "      Z position = 0.00098 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6697\n",
+      "-----\n",
+      "t = 0.025s (step 26/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.572 -1.245]\n",
+      "      Z position = 0.00104 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6695\n",
+      "-----\n",
+      "t = 0.026s (step 27/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.572 -1.245]\n",
+      "      Z position = 0.00108 [m]\n",
+      "      beta_p/li = 0.2995 / 0.6694\n",
+      "-----\n",
+      "t = 0.027s (step 28/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.572 -1.244]\n",
+      "      Z position = 0.00112 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6694\n",
+      "-----\n",
+      "t = 0.028s (step 29/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.572 -1.244]\n",
+      "      Z position = 0.00116 [m]\n",
+      "      beta_p/li = 0.299 / 0.6694\n",
+      "-----\n",
+      "t = 0.029s (step 30/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.572 -1.244]\n",
+      "      Z position = 0.0012 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6693\n",
+      "-----\n",
+      "t = 0.03s (step 31/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.572 -1.244]\n",
+      "      Z position = 0.00124 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6693\n",
+      "-----\n",
+      "t = 0.031s (step 32/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.572 -1.244]\n",
+      "      Z position = 0.00127 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6708\n",
+      "-----\n",
+      "t = 0.032s (step 33/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.353  0.572 -1.245]\n",
+      "      Z position = 0.00127 [m]\n",
+      "      beta_p/li = 0.3 / 0.6714\n",
+      "-----\n",
+      "t = 0.033s (step 34/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.573 -1.245]\n",
+      "      Z position = 0.00129 [m]\n",
+      "      beta_p/li = 0.3014 / 0.6707\n",
+      "-----\n",
+      "t = 0.034s (step 35/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.284  1.354  0.573 -1.246]\n",
+      "      Z position = 0.00137 [m]\n",
+      "      beta_p/li = 0.3017 / 0.6698\n",
+      "-----\n",
+      "t = 0.035s (step 36/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.284  1.353  0.573 -1.246]\n",
+      "      Z position = 0.00144 [m]\n",
+      "      beta_p/li = 0.3009 / 0.6692\n",
+      "-----\n",
+      "t = 0.036s (step 37/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.352  0.572 -1.246]\n",
+      "      Z position = 0.0015 [m]\n",
+      "      beta_p/li = 0.2998 / 0.669\n",
+      "-----\n",
+      "t = 0.037s (step 38/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.351  0.572 -1.245]\n",
+      "      Z position = 0.00154 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6664\n",
+      "-----\n",
+      "t = 0.038s (step 39/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.35   0.572 -1.244]\n",
+      "      Z position = 0.00166 [m]\n",
+      "      beta_p/li = 0.2959 / 0.6674\n",
+      "-----\n",
+      "t = 0.039s (step 40/499)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/zn8047/Documents/freegs4e/freegs4e/critical.py:1045: UserWarning: Theta grid too close to X-point, shifting by half-step\n",
+      "  warnings.warn(\"Theta grid too close to X-point, shifting by half-step\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.572 -1.244]\n",
+      "      Z position = 0.00164 [m]\n",
+      "      beta_p/li = 0.295 / 0.6672\n",
+      "-----\n",
+      "t = 0.04s (step 41/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.571 -1.244]\n",
+      "      Z position = 0.00165 [m]\n",
+      "      beta_p/li = 0.2942 / 0.6697\n",
+      "-----\n",
+      "t = 0.041s (step 42/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.572 -1.244]\n",
+      "      Z position = 0.00164 [m]\n",
+      "      beta_p/li = 0.296 / 0.6726\n",
+      "-----\n",
+      "t = 0.042s (step 43/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.573 -1.245]\n",
+      "      Z position = 0.00159 [m]\n",
+      "      beta_p/li = 0.3001 / 0.6723\n",
+      "-----\n",
+      "t = 0.043s (step 44/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.284  1.357  0.573 -1.246]\n",
+      "      Z position = 0.00175 [m]\n",
+      "      beta_p/li = 0.3025 / 0.6695\n",
+      "-----\n",
+      "t = 0.044s (step 45/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.284  1.356  0.573 -1.246]\n",
+      "      Z position = 0.00175 [m]\n",
+      "      beta_p/li = 0.301 / 0.6697\n",
+      "-----\n",
+      "t = 0.045s (step 46/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.284  1.355  0.573 -1.246]\n",
+      "      Z position = 0.00184 [m]\n",
+      "      beta_p/li = 0.3003 / 0.6695\n",
+      "-----\n",
+      "t = 0.046s (step 47/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.573 -1.246]\n",
+      "      Z position = 0.00189 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6689\n",
+      "-----\n",
+      "t = 0.047s (step 48/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00196 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6686\n",
+      "-----\n",
+      "t = 0.048s (step 49/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.353  0.572 -1.246]\n",
+      "      Z position = 0.00197 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6693\n",
+      "-----\n",
+      "t = 0.049s (step 50/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.353  0.572 -1.246]\n",
+      "      Z position = 0.00199 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6692\n",
+      "-----\n",
+      "t = 0.05s (step 51/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00203 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6695\n",
+      "-----\n",
+      "t = 0.051s (step 52/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00207 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6693\n",
+      "-----\n",
+      "t = 0.052s (step 53/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00211 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6693\n",
+      "-----\n",
+      "t = 0.053s (step 54/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00216 [m]\n",
+      "      beta_p/li = 0.298 / 0.6692\n",
+      "-----\n",
+      "t = 0.054s (step 55/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00221 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6692\n",
+      "-----\n",
+      "t = 0.055s (step 56/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.572 -1.246]\n",
+      "      Z position = 0.00225 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6692\n",
+      "-----\n",
+      "t = 0.056s (step 57/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.354  0.571 -1.246]\n",
+      "      Z position = 0.00229 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6692\n",
+      "-----\n",
+      "t = 0.057s (step 58/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.571 -1.247]\n",
+      "      Z position = 0.00233 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6692\n",
+      "-----\n",
+      "t = 0.058s (step 59/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.571 -1.247]\n",
+      "      Z position = 0.00238 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6697\n",
+      "-----\n",
+      "t = 0.059s (step 60/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.571 -1.247]\n",
+      "      Z position = 0.00244 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6693\n",
+      "-----\n",
+      "t = 0.06s (step 61/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.57  -1.247]\n",
+      "      Z position = 0.00245 [m]\n",
+      "      beta_p/li = 0.298 / 0.6693\n",
+      "-----\n",
+      "t = 0.061s (step 62/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.57  -1.247]\n",
+      "      Z position = 0.0025 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6692\n",
+      "-----\n",
+      "t = 0.062s (step 63/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.569 -1.247]\n",
+      "      Z position = 0.00253 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6692\n",
+      "-----\n",
+      "t = 0.063s (step 64/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.569 -1.247]\n",
+      "      Z position = 0.00258 [m]\n",
+      "      beta_p/li = 0.2976 / 0.669\n",
+      "-----\n",
+      "t = 0.064s (step 65/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.568 -1.247]\n",
+      "      Z position = 0.00261 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6691\n",
+      "-----\n",
+      "t = 0.065s (step 66/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.568 -1.247]\n",
+      "      Z position = 0.00266 [m]\n",
+      "      beta_p/li = 0.2973 / 0.669\n",
+      "-----\n",
+      "t = 0.066s (step 67/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.567 -1.247]\n",
+      "      Z position = 0.00269 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6691\n",
+      "-----\n",
+      "t = 0.067s (step 68/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.567 -1.248]\n",
+      "      Z position = 0.00273 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6688\n",
+      "-----\n",
+      "t = 0.068s (step 69/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.566 -1.248]\n",
+      "      Z position = 0.00277 [m]\n",
+      "      beta_p/li = 0.2969 / 0.6691\n",
+      "-----\n",
+      "t = 0.069s (step 70/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.566 -1.248]\n",
+      "      Z position = 0.00282 [m]\n",
+      "      beta_p/li = 0.297 / 0.6688\n",
+      "-----\n",
+      "t = 0.07s (step 71/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.565 -1.248]\n",
+      "      Z position = 0.00285 [m]\n",
+      "      beta_p/li = 0.2967 / 0.6691\n",
+      "-----\n",
+      "t = 0.071s (step 72/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.564 -1.248]\n",
+      "      Z position = 0.0029 [m]\n",
+      "      beta_p/li = 0.2968 / 0.6691\n",
+      "-----\n",
+      "t = 0.072s (step 73/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.564 -1.248]\n",
+      "      Z position = 0.00293 [m]\n",
+      "      beta_p/li = 0.297 / 0.6692\n",
+      "-----\n",
+      "t = 0.073s (step 74/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.563 -1.248]\n",
+      "      Z position = 0.00297 [m]\n",
+      "      beta_p/li = 0.2971 / 0.6692\n",
+      "-----\n",
+      "t = 0.074s (step 75/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.562 -1.248]\n",
+      "      Z position = 0.00301 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6691\n",
+      "-----\n",
+      "t = 0.075s (step 76/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.562 -1.248]\n",
+      "      Z position = 0.00305 [m]\n",
+      "      beta_p/li = 0.2971 / 0.6691\n",
+      "-----\n",
+      "t = 0.076s (step 77/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.561 -1.248]\n",
+      "      Z position = 0.00309 [m]\n",
+      "      beta_p/li = 0.2971 / 0.6693\n",
+      "-----\n",
+      "t = 0.077s (step 78/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.561 -1.249]\n",
+      "      Z position = 0.00313 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6689\n",
+      "-----\n",
+      "t = 0.078s (step 79/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.356  0.56  -1.249]\n",
+      "      Z position = 0.00316 [m]\n",
+      "      beta_p/li = 0.2969 / 0.6693\n",
+      "-----\n",
+      "t = 0.079s (step 80/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.559 -1.249]\n",
+      "      Z position = 0.00317 [m]\n",
+      "      beta_p/li = 0.2971 / 0.669\n",
+      "-----\n",
+      "t = 0.08s (step 81/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.559 -1.249]\n",
+      "      Z position = 0.00325 [m]\n",
+      "      beta_p/li = 0.297 / 0.6693\n",
+      "-----\n",
+      "t = 0.081s (step 82/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.558 -1.249]\n",
+      "      Z position = 0.00329 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6694\n",
+      "-----\n",
+      "t = 0.082s (step 83/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.557 -1.25 ]\n",
+      "      Z position = 0.0033 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6695\n",
+      "-----\n",
+      "t = 0.083s (step 84/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.556 -1.25 ]\n",
+      "      Z position = 0.00334 [m]\n",
+      "      beta_p/li = 0.2976 / 0.6695\n",
+      "-----\n",
+      "t = 0.084s (step 85/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.555 -1.25 ]\n",
+      "      Z position = 0.00338 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6695\n",
+      "-----\n",
+      "t = 0.085s (step 86/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.554 -1.25 ]\n",
+      "      Z position = 0.00343 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6695\n",
+      "-----\n",
+      "t = 0.086s (step 87/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.554 -1.25 ]\n",
+      "      Z position = 0.00347 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6695\n",
+      "-----\n",
+      "t = 0.087s (step 88/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.356  0.553 -1.25 ]\n",
+      "      Z position = 0.00352 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6695\n",
+      "-----\n",
+      "t = 0.088s (step 89/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.552 -1.25 ]\n",
+      "      Z position = 0.00356 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6685\n",
+      "-----\n",
+      "t = 0.089s (step 90/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.551 -1.25 ]\n",
+      "      Z position = 0.00364 [m]\n",
+      "      beta_p/li = 0.297 / 0.669\n",
+      "-----\n",
+      "t = 0.09s (step 91/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.55  -1.25 ]\n",
+      "      Z position = 0.00366 [m]\n",
+      "      beta_p/li = 0.2969 / 0.6696\n",
+      "-----\n",
+      "t = 0.091s (step 92/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.549 -1.25 ]\n",
+      "      Z position = 0.00367 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6691\n",
+      "-----\n",
+      "t = 0.092s (step 93/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.548 -1.25 ]\n",
+      "      Z position = 0.00373 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6708\n",
+      "-----\n",
+      "t = 0.093s (step 94/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.283  1.355  0.547 -1.251]\n",
+      "      Z position = 0.00377 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6692\n",
+      "-----\n",
+      "t = 0.094s (step 95/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.546 -1.251]\n",
+      "      Z position = 0.00379 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6693\n",
+      "-----\n",
+      "t = 0.095s (step 96/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.545 -1.251]\n",
+      "      Z position = 0.00387 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6699\n",
+      "-----\n",
+      "t = 0.096s (step 97/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.545 -1.251]\n",
+      "      Z position = 0.00391 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6694\n",
+      "-----\n",
+      "t = 0.097s (step 98/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.354  0.544 -1.251]\n",
+      "      Z position = 0.00392 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6693\n",
+      "-----\n",
+      "t = 0.098s (step 99/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.354  0.543 -1.251]\n",
+      "      Z position = 0.00398 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6692\n",
+      "-----\n",
+      "t = 0.099s (step 100/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.354  0.542 -1.251]\n",
+      "      Z position = 0.00402 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6696\n",
+      "-----\n",
+      "t = 0.1s (step 101/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.354  0.541 -1.251]\n",
+      "      Z position = 0.00408 [m]\n",
+      "      beta_p/li = 0.298 / 0.6693\n",
+      "-----\n",
+      "t = 0.101s (step 102/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.54  -1.251]\n",
+      "      Z position = 0.00409 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6693\n",
+      "-----\n",
+      "t = 0.102s (step 103/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.539 -1.251]\n",
+      "      Z position = 0.00415 [m]\n",
+      "      beta_p/li = 0.2977 / 0.67\n",
+      "-----\n",
+      "t = 0.103s (step 104/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.539 -1.251]\n",
+      "      Z position = 0.00421 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6687\n",
+      "-----\n",
+      "t = 0.104s (step 105/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.538 -1.251]\n",
+      "      Z position = 0.00417 [m]\n",
+      "      beta_p/li = 0.2974 / 0.67\n",
+      "-----\n",
+      "t = 0.105s (step 106/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.537 -1.251]\n",
+      "      Z position = 0.00433 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6693\n",
+      "-----\n",
+      "t = 0.106s (step 107/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.536 -1.251]\n",
+      "      Z position = 0.00427 [m]\n",
+      "      beta_p/li = 0.2979 / 0.67\n",
+      "-----\n",
+      "t = 0.107s (step 108/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.535 -1.252]\n",
+      "      Z position = 0.00439 [m]\n",
+      "      beta_p/li = 0.2985 / 0.6695\n",
+      "-----\n",
+      "t = 0.108s (step 109/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.534 -1.252]\n",
+      "      Z position = 0.00436 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6695\n",
+      "-----\n",
+      "t = 0.109s (step 110/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.534 -1.252]\n",
+      "      Z position = 0.00444 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6695\n",
+      "-----\n",
+      "t = 0.11s (step 111/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.533 -1.252]\n",
+      "      Z position = 0.00446 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6695\n",
+      "-----\n",
+      "t = 0.111s (step 112/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.532 -1.252]\n",
+      "      Z position = 0.00451 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6696\n",
+      "-----\n",
+      "t = 0.112s (step 113/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.531 -1.252]\n",
+      "      Z position = 0.00455 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6693\n",
+      "-----\n",
+      "t = 0.113s (step 114/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.531 -1.252]\n",
+      "      Z position = 0.00456 [m]\n",
+      "      beta_p/li = 0.298 / 0.669\n",
+      "-----\n",
+      "t = 0.114s (step 115/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.53  -1.252]\n",
+      "      Z position = 0.00469 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6692\n",
+      "-----\n",
+      "t = 0.115s (step 116/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.529 -1.252]\n",
+      "      Z position = 0.00467 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6695\n",
+      "-----\n",
+      "t = 0.116s (step 117/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.529 -1.253]\n",
+      "      Z position = 0.00461 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6694\n",
+      "-----\n",
+      "t = 0.117s (step 118/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.528 -1.253]\n",
+      "      Z position = 0.00481 [m]\n",
+      "      beta_p/li = 0.298 / 0.6693\n",
+      "-----\n",
+      "t = 0.118s (step 119/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.527 -1.252]\n",
+      "      Z position = 0.00478 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6695\n",
+      "-----\n",
+      "t = 0.119s (step 120/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.526 -1.252]\n",
+      "      Z position = 0.00487 [m]\n",
+      "      beta_p/li = 0.298 / 0.6694\n",
+      "-----\n",
+      "t = 0.12s (step 121/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.525 -1.252]\n",
+      "      Z position = 0.00487 [m]\n",
+      "      beta_p/li = 0.298 / 0.6695\n",
+      "-----\n",
+      "t = 0.121s (step 122/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.524 -1.252]\n",
+      "      Z position = 0.00493 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6694\n",
+      "-----\n",
+      "t = 0.122s (step 123/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.524 -1.252]\n",
+      "      Z position = 0.00495 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6688\n",
+      "-----\n",
+      "t = 0.123s (step 124/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.523 -1.252]\n",
+      "      Z position = 0.00496 [m]\n",
+      "      beta_p/li = 0.2975 / 0.669\n",
+      "-----\n",
+      "t = 0.124s (step 125/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.522 -1.252]\n",
+      "      Z position = 0.00506 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6696\n",
+      "-----\n",
+      "t = 0.125s (step 126/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.521 -1.252]\n",
+      "      Z position = 0.00511 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6696\n",
+      "-----\n",
+      "t = 0.126s (step 127/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.52  -1.252]\n",
+      "      Z position = 0.00511 [m]\n",
+      "      beta_p/li = 0.298 / 0.6692\n",
+      "-----\n",
+      "t = 0.127s (step 128/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.52  -1.252]\n",
+      "      Z position = 0.00514 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6699\n",
+      "-----\n",
+      "t = 0.128s (step 129/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.519 -1.252]\n",
+      "      Z position = 0.00524 [m]\n",
+      "      beta_p/li = 0.2985 / 0.6688\n",
+      "-----\n",
+      "t = 0.129s (step 130/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.518 -1.252]\n",
+      "      Z position = 0.00515 [m]\n",
+      "      beta_p/li = 0.2977 / 0.67\n",
+      "-----\n",
+      "t = 0.13s (step 131/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.518 -1.252]\n",
+      "      Z position = 0.00537 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6693\n",
+      "-----\n",
+      "t = 0.131s (step 132/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.517 -1.252]\n",
+      "      Z position = 0.00522 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6695\n",
+      "-----\n",
+      "t = 0.132s (step 133/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.516 -1.252]\n",
+      "      Z position = 0.00539 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6692\n",
+      "-----\n",
+      "t = 0.133s (step 134/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.515 -1.252]\n",
+      "      Z position = 0.00534 [m]\n",
+      "      beta_p/li = 0.298 / 0.6695\n",
+      "-----\n",
+      "t = 0.134s (step 135/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.515 -1.252]\n",
+      "      Z position = 0.00545 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6693\n",
+      "-----\n",
+      "t = 0.135s (step 136/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.514 -1.252]\n",
+      "      Z position = 0.00544 [m]\n",
+      "      beta_p/li = 0.298 / 0.6694\n",
+      "-----\n",
+      "t = 0.136s (step 137/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.513 -1.252]\n",
+      "      Z position = 0.00553 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6693\n",
+      "-----\n",
+      "t = 0.137s (step 138/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.512 -1.251]\n",
+      "      Z position = 0.00554 [m]\n",
+      "      beta_p/li = 0.298 / 0.6694\n",
+      "-----\n",
+      "t = 0.138s (step 139/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.512 -1.251]\n",
+      "      Z position = 0.0056 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6694\n",
+      "-----\n",
+      "t = 0.139s (step 140/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.511 -1.251]\n",
+      "      Z position = 0.00562 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6694\n",
+      "-----\n",
+      "t = 0.14s (step 141/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.51  -1.251]\n",
+      "      Z position = 0.00568 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6694\n",
+      "-----\n",
+      "t = 0.141s (step 142/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.51  -1.251]\n",
+      "      Z position = 0.00571 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6694\n",
+      "-----\n",
+      "t = 0.142s (step 143/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.509 -1.251]\n",
+      "      Z position = 0.00575 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6694\n",
+      "-----\n",
+      "t = 0.143s (step 144/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.508 -1.251]\n",
+      "      Z position = 0.00579 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6695\n",
+      "-----\n",
+      "t = 0.144s (step 145/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.508 -1.251]\n",
+      "      Z position = 0.00583 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6699\n",
+      "-----\n",
+      "t = 0.145s (step 146/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.507 -1.251]\n",
+      "      Z position = 0.00587 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6696\n",
+      "-----\n",
+      "t = 0.146s (step 147/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.506 -1.251]\n",
+      "      Z position = 0.00589 [m]\n",
+      "      beta_p/li = 0.2987 / 0.67\n",
+      "-----\n",
+      "t = 0.147s (step 148/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.506 -1.251]\n",
+      "      Z position = 0.00595 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6697\n",
+      "-----\n",
+      "t = 0.148s (step 149/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.505 -1.251]\n",
+      "      Z position = 0.00597 [m]\n",
+      "      beta_p/li = 0.299 / 0.6696\n",
+      "-----\n",
+      "t = 0.149s (step 150/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.504 -1.251]\n",
+      "      Z position = 0.00602 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6696\n",
+      "-----\n",
+      "t = 0.15s (step 151/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.503 -1.251]\n",
+      "      Z position = 0.00606 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6696\n",
+      "-----\n",
+      "t = 0.151s (step 152/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.503 -1.251]\n",
+      "      Z position = 0.0061 [m]\n",
+      "      beta_p/li = 0.2987 / 0.67\n",
+      "-----\n",
+      "t = 0.152s (step 153/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.502 -1.251]\n",
+      "      Z position = 0.00615 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6696\n",
+      "-----\n",
+      "t = 0.153s (step 154/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.502 -1.251]\n",
+      "      Z position = 0.00617 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6694\n",
+      "-----\n",
+      "t = 0.154s (step 155/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.502 -1.252]\n",
+      "      Z position = 0.00623 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6681\n",
+      "-----\n",
+      "t = 0.155s (step 156/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.501 -1.251]\n",
+      "      Z position = 0.00629 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6669\n",
+      "-----\n",
+      "t = 0.156s (step 157/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.348  0.5   -1.251]\n",
+      "      Z position = 0.00634 [m]\n",
+      "      beta_p/li = 0.2953 / 0.6682\n",
+      "-----\n",
+      "t = 0.157s (step 158/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.5   -1.25 ]\n",
+      "      Z position = 0.00638 [m]\n",
+      "      beta_p/li = 0.2952 / 0.6687\n",
+      "-----\n",
+      "t = 0.158s (step 159/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.499 -1.25 ]\n",
+      "      Z position = 0.00641 [m]\n",
+      "      beta_p/li = 0.2956 / 0.6701\n",
+      "-----\n",
+      "t = 0.159s (step 160/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.5   -1.25 ]\n",
+      "      Z position = 0.00651 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6718\n",
+      "-----\n",
+      "t = 0.16s (step 161/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.5   -1.251]\n",
+      "      Z position = 0.00648 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6697\n",
+      "-----\n",
+      "t = 0.161s (step 162/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.499 -1.251]\n",
+      "      Z position = 0.00643 [m]\n",
+      "      beta_p/li = 0.2994 / 0.6697\n",
+      "-----\n",
+      "t = 0.162s (step 163/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.499 -1.251]\n",
+      "      Z position = 0.00654 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6695\n",
+      "-----\n",
+      "t = 0.163s (step 164/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.499 -1.251]\n",
+      "      Z position = 0.00654 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6696\n",
+      "-----\n",
+      "t = 0.164s (step 165/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.498 -1.251]\n",
+      "      Z position = 0.0066 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6695\n",
+      "-----\n",
+      "t = 0.165s (step 166/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.498 -1.251]\n",
+      "      Z position = 0.00664 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6695\n",
+      "-----\n",
+      "t = 0.166s (step 167/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.498 -1.251]\n",
+      "      Z position = 0.00657 [m]\n",
+      "      beta_p/li = 0.2984 / 0.6681\n",
+      "-----\n",
+      "t = 0.167s (step 168/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.498 -1.25 ]\n",
+      "      Z position = 0.00678 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6677\n",
+      "-----\n",
+      "t = 0.168s (step 169/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.497 -1.25 ]\n",
+      "      Z position = 0.00677 [m]\n",
+      "      beta_p/li = 0.296 / 0.6678\n",
+      "-----\n",
+      "t = 0.169s (step 170/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.497 -1.249]\n",
+      "      Z position = 0.00684 [m]\n",
+      "      beta_p/li = 0.2953 / 0.6687\n",
+      "-----\n",
+      "t = 0.17s (step 171/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.497 -1.249]\n",
+      "      Z position = 0.0069 [m]\n",
+      "      beta_p/li = 0.2957 / 0.6701\n",
+      "-----\n",
+      "t = 0.171s (step 172/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.351  0.497 -1.249]\n",
+      "      Z position = 0.007 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6718\n",
+      "-----\n",
+      "t = 0.172s (step 173/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.498 -1.25 ]\n",
+      "      Z position = 0.00697 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6702\n",
+      "-----\n",
+      "t = 0.173s (step 174/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.498 -1.25 ]\n",
+      "      Z position = 0.00691 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6698\n",
+      "-----\n",
+      "t = 0.174s (step 175/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.498 -1.25 ]\n",
+      "      Z position = 0.00701 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6696\n",
+      "-----\n",
+      "t = 0.175s (step 176/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.498 -1.25 ]\n",
+      "      Z position = 0.00703 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6696\n",
+      "-----\n",
+      "t = 0.176s (step 177/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.498 -1.25 ]\n",
+      "      Z position = 0.0071 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6681\n",
+      "-----\n",
+      "t = 0.177s (step 178/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.497 -1.25 ]\n",
+      "      Z position = 0.00714 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6669\n",
+      "-----\n",
+      "t = 0.178s (step 179/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.497 -1.249]\n",
+      "      Z position = 0.00714 [m]\n",
+      "      beta_p/li = 0.2954 / 0.6691\n",
+      "-----\n",
+      "t = 0.179s (step 180/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.497 -1.249]\n",
+      "      Z position = 0.00729 [m]\n",
+      "      beta_p/li = 0.2961 / 0.6686\n",
+      "-----\n",
+      "t = 0.18s (step 181/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.497 -1.249]\n",
+      "      Z position = 0.00726 [m]\n",
+      "      beta_p/li = 0.296 / 0.6691\n",
+      "-----\n",
+      "t = 0.181s (step 182/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.498 -1.249]\n",
+      "      Z position = 0.00734 [m]\n",
+      "      beta_p/li = 0.2965 / 0.6702\n",
+      "-----\n",
+      "t = 0.182s (step 183/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.351  0.498 -1.249]\n",
+      "      Z position = 0.00742 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6719\n",
+      "-----\n",
+      "t = 0.183s (step 184/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.499 -1.25 ]\n",
+      "      Z position = 0.00756 [m]\n",
+      "      beta_p/li = 0.3004 / 0.6703\n",
+      "-----\n",
+      "t = 0.184s (step 185/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.499 -1.25 ]\n",
+      "      Z position = 0.00727 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6702\n",
+      "-----\n",
+      "t = 0.185s (step 186/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.499 -1.25 ]\n",
+      "      Z position = 0.00746 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6696\n",
+      "-----\n",
+      "t = 0.186s (step 187/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.499 -1.25 ]\n",
+      "      Z position = 0.00746 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6677\n",
+      "-----\n",
+      "t = 0.187s (step 188/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.498 -1.249]\n",
+      "      Z position = 0.00751 [m]\n",
+      "      beta_p/li = 0.2976 / 0.6677\n",
+      "-----\n",
+      "t = 0.188s (step 189/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.498 -1.249]\n",
+      "      Z position = 0.00742 [m]\n",
+      "      beta_p/li = 0.2962 / 0.6674\n",
+      "-----\n",
+      "t = 0.189s (step 190/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.498 -1.248]\n",
+      "      Z position = 0.00765 [m]\n",
+      "      beta_p/li = 0.2953 / 0.6685\n",
+      "-----\n",
+      "t = 0.19s (step 191/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.498 -1.248]\n",
+      "      Z position = 0.00783 [m]\n",
+      "      beta_p/li = 0.2955 / 0.6705\n",
+      "-----\n",
+      "t = 0.191s (step 192/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.498 -1.248]\n",
+      "      Z position = 0.00777 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6708\n",
+      "-----\n",
+      "t = 0.192s (step 193/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.499 -1.249]\n",
+      "      Z position = 0.00778 [m]\n",
+      "      beta_p/li = 0.299 / 0.6722\n",
+      "-----\n",
+      "t = 0.193s (step 194/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.5   -1.25 ]\n",
+      "      Z position = 0.00785 [m]\n",
+      "      beta_p/li = 0.3014 / 0.6701\n",
+      "-----\n",
+      "t = 0.194s (step 195/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28  1.35  0.5  -1.25]\n",
+      "      Z position = 0.00767 [m]\n",
+      "      beta_p/li = 0.3007 / 0.6702\n",
+      "-----\n",
+      "t = 0.195s (step 196/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28  1.35  0.5  -1.25]\n",
+      "      Z position = 0.00789 [m]\n",
+      "      beta_p/li = 0.3007 / 0.6683\n",
+      "-----\n",
+      "t = 0.196s (step 197/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.499 -1.249]\n",
+      "      Z position = 0.00787 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6671\n",
+      "-----\n",
+      "t = 0.197s (step 198/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.499 -1.249]\n",
+      "      Z position = 0.00783 [m]\n",
+      "      beta_p/li = 0.2964 / 0.6673\n",
+      "-----\n",
+      "t = 0.198s (step 199/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.499 -1.248]\n",
+      "      Z position = 0.00799 [m]\n",
+      "      beta_p/li = 0.2952 / 0.6685\n",
+      "-----\n",
+      "t = 0.199s (step 200/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.499 -1.248]\n",
+      "      Z position = 0.00811 [m]\n",
+      "      beta_p/li = 0.2955 / 0.6689\n",
+      "-----\n",
+      "t = 0.2s (step 201/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.499 -1.248]\n",
+      "      Z position = 0.00811 [m]\n",
+      "      beta_p/li = 0.296 / 0.6706\n",
+      "-----\n",
+      "t = 0.201s (step 202/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.499 -1.248]\n",
+      "      Z position = 0.00821 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6721\n",
+      "-----\n",
+      "t = 0.202s (step 203/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.5   -1.249]\n",
+      "      Z position = 0.00824 [m]\n",
+      "      beta_p/li = 0.3006 / 0.6708\n",
+      "-----\n",
+      "t = 0.203s (step 204/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.5   -1.249]\n",
+      "      Z position = 0.00809 [m]\n",
+      "      beta_p/li = 0.3009 / 0.6702\n",
+      "-----\n",
+      "t = 0.204s (step 205/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.5   -1.249]\n",
+      "      Z position = 0.00818 [m]\n",
+      "      beta_p/li = 0.3007 / 0.6698\n",
+      "-----\n",
+      "t = 0.205s (step 206/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.5   -1.249]\n",
+      "      Z position = 0.00824 [m]\n",
+      "      beta_p/li = 0.3001 / 0.6672\n",
+      "-----\n",
+      "t = 0.206s (step 207/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.348  0.5   -1.248]\n",
+      "      Z position = 0.00823 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6685\n",
+      "-----\n",
+      "t = 0.207s (step 208/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.348  0.5   -1.248]\n",
+      "      Z position = 0.00836 [m]\n",
+      "      beta_p/li = 0.2969 / 0.669\n",
+      "-----\n",
+      "t = 0.208s (step 209/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.248]\n",
+      "      Z position = 0.0084 [m]\n",
+      "      beta_p/li = 0.297 / 0.6692\n",
+      "-----\n",
+      "t = 0.209s (step 210/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.248]\n",
+      "      Z position = 0.00845 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6693\n",
+      "-----\n",
+      "t = 0.21s (step 211/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.248]\n",
+      "      Z position = 0.00849 [m]\n",
+      "      beta_p/li = 0.2976 / 0.6693\n",
+      "-----\n",
+      "t = 0.211s (step 212/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.247]\n",
+      "      Z position = 0.00853 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6704\n",
+      "-----\n",
+      "t = 0.212s (step 213/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.248]\n",
+      "      Z position = 0.00858 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6704\n",
+      "-----\n",
+      "t = 0.213s (step 214/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.248]\n",
+      "      Z position = 0.00858 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6698\n",
+      "-----\n",
+      "t = 0.214s (step 215/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.248]\n",
+      "      Z position = 0.00861 [m]\n",
+      "      beta_p/li = 0.2995 / 0.6696\n",
+      "-----\n",
+      "t = 0.215s (step 216/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.248]\n",
+      "      Z position = 0.00866 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6685\n",
+      "-----\n",
+      "t = 0.216s (step 217/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.248]\n",
+      "      Z position = 0.00869 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6684\n",
+      "-----\n",
+      "t = 0.217s (step 218/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.247]\n",
+      "      Z position = 0.00872 [m]\n",
+      "      beta_p/li = 0.2972 / 0.669\n",
+      "-----\n",
+      "t = 0.218s (step 219/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.247]\n",
+      "      Z position = 0.00881 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6697\n",
+      "-----\n",
+      "t = 0.219s (step 220/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.247]\n",
+      "      Z position = 0.00885 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6702\n",
+      "-----\n",
+      "t = 0.22s (step 221/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.501 -1.247]\n",
+      "      Z position = 0.00888 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6698\n",
+      "-----\n",
+      "t = 0.221s (step 222/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.0089 [m]\n",
+      "      beta_p/li = 0.299 / 0.6696\n",
+      "-----\n",
+      "t = 0.222s (step 223/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.00894 [m]\n",
+      "      beta_p/li = 0.2989 / 0.67\n",
+      "-----\n",
+      "t = 0.223s (step 224/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.00899 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6691\n",
+      "-----\n",
+      "t = 0.224s (step 225/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.009 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6688\n",
+      "-----\n",
+      "t = 0.225s (step 226/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.247]\n",
+      "      Z position = 0.00906 [m]\n",
+      "      beta_p/li = 0.298 / 0.6695\n",
+      "-----\n",
+      "t = 0.226s (step 227/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.501 -1.247]\n",
+      "      Z position = 0.00911 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6691\n",
+      "-----\n",
+      "t = 0.227s (step 228/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.247]\n",
+      "      Z position = 0.00914 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6693\n",
+      "-----\n",
+      "t = 0.228s (step 229/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.501 -1.247]\n",
+      "      Z position = 0.00919 [m]\n",
+      "      beta_p/li = 0.298 / 0.6704\n",
+      "-----\n",
+      "t = 0.229s (step 230/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00924 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6714\n",
+      "-----\n",
+      "t = 0.23s (step 231/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.247]\n",
+      "      Z position = 0.00935 [m]\n",
+      "      beta_p/li = 0.3008 / 0.6698\n",
+      "-----\n",
+      "t = 0.231s (step 232/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.00915 [m]\n",
+      "      beta_p/li = 0.3001 / 0.6699\n",
+      "-----\n",
+      "t = 0.232s (step 233/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.00937 [m]\n",
+      "      beta_p/li = 0.3 / 0.6681\n",
+      "-----\n",
+      "t = 0.233s (step 234/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.5   -1.247]\n",
+      "      Z position = 0.00935 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6671\n",
+      "-----\n",
+      "t = 0.234s (step 235/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.348  0.5   -1.246]\n",
+      "      Z position = 0.00936 [m]\n",
+      "      beta_p/li = 0.2961 / 0.669\n",
+      "-----\n",
+      "t = 0.235s (step 236/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.00956 [m]\n",
+      "      beta_p/li = 0.2966 / 0.6686\n",
+      "-----\n",
+      "t = 0.236s (step 237/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.0095 [m]\n",
+      "      beta_p/li = 0.2964 / 0.6702\n",
+      "-----\n",
+      "t = 0.237s (step 238/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.5   -1.246]\n",
+      "      Z position = 0.00964 [m]\n",
+      "      beta_p/li = 0.2979 / 0.67\n",
+      "-----\n",
+      "t = 0.238s (step 239/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00962 [m]\n",
+      "      beta_p/li = 0.2986 / 0.671\n",
+      "-----\n",
+      "t = 0.239s (step 240/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.247]\n",
+      "      Z position = 0.00969 [m]\n",
+      "      beta_p/li = 0.3 / 0.6702\n",
+      "-----\n",
+      "t = 0.24s (step 241/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00959 [m]\n",
+      "      beta_p/li = 0.3001 / 0.6699\n",
+      "-----\n",
+      "t = 0.241s (step 242/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00967 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6696\n",
+      "-----\n",
+      "t = 0.242s (step 243/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00969 [m]\n",
+      "      beta_p/li = 0.2969 / 0.6848\n",
+      "-----\n",
+      "t = 0.243s (step 244/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.286  1.358  0.503 -1.25 ]\n",
+      "      Z position = 0.00952 [m]\n",
+      "      beta_p/li = 0.3149 / 0.6596\n",
+      "-----\n",
+      "t = 0.244s (step 245/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.348  0.501 -1.248]\n",
+      "      Z position = 0.00984 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6629\n",
+      "-----\n",
+      "t = 0.245s (step 246/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.246]\n",
+      "      Z position = 0.00965 [m]\n",
+      "      beta_p/li = 0.2929 / 0.6652\n",
+      "-----\n",
+      "t = 0.246s (step 247/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2912 / 0.6677\n",
+      "-----\n",
+      "t = 0.247s (step 248/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.347  0.499 -1.244]\n",
+      "      Z position = 0.0101 [m]\n",
+      "      beta_p/li = 0.2921 / 0.6696\n",
+      "-----\n",
+      "t = 0.248s (step 249/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.499 -1.245]\n",
+      "      Z position = 0.01019 [m]\n",
+      "      beta_p/li = 0.2944 / 0.6715\n",
+      "-----\n",
+      "t = 0.249s (step 250/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.5   -1.245]\n",
+      "      Z position = 0.01031 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6713\n",
+      "-----\n",
+      "t = 0.25s (step 251/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.01006 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6706\n",
+      "-----\n",
+      "t = 0.251s (step 252/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6699\n",
+      "-----\n",
+      "t = 0.252s (step 253/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00995 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6698\n",
+      "-----\n",
+      "t = 0.253s (step 254/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6696\n",
+      "-----\n",
+      "t = 0.254s (step 255/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6696\n",
+      "-----\n",
+      "t = 0.255s (step 256/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6695\n",
+      "-----\n",
+      "t = 0.256s (step 257/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6682\n",
+      "-----\n",
+      "t = 0.257s (step 258/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6679\n",
+      "-----\n",
+      "t = 0.258s (step 259/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2964 / 0.6688\n",
+      "-----\n",
+      "t = 0.259s (step 260/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.246]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2966 / 0.6691\n",
+      "-----\n",
+      "t = 0.26s (step 261/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2969 / 0.6703\n",
+      "-----\n",
+      "t = 0.261s (step 262/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.0101 [m]\n",
+      "      beta_p/li = 0.2983 / 0.671\n",
+      "-----\n",
+      "t = 0.262s (step 263/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01007 [m]\n",
+      "      beta_p/li = 0.2998 / 0.67\n",
+      "-----\n",
+      "t = 0.263s (step 264/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6698\n",
+      "-----\n",
+      "t = 0.264s (step 265/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6696\n",
+      "-----\n",
+      "t = 0.265s (step 266/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6696\n",
+      "-----\n",
+      "t = 0.266s (step 267/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6681\n",
+      "-----\n",
+      "t = 0.267s (step 268/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2976 / 0.6679\n",
+      "-----\n",
+      "t = 0.268s (step 269/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2965 / 0.6688\n",
+      "-----\n",
+      "t = 0.269s (step 270/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2966 / 0.6691\n",
+      "-----\n",
+      "t = 0.27s (step 271/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.297 / 0.6703\n",
+      "-----\n",
+      "t = 0.271s (step 272/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.0101 [m]\n",
+      "      beta_p/li = 0.2984 / 0.671\n",
+      "-----\n",
+      "t = 0.272s (step 273/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01008 [m]\n",
+      "      beta_p/li = 0.2998 / 0.67\n",
+      "-----\n",
+      "t = 0.273s (step 274/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00991 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6698\n",
+      "-----\n",
+      "t = 0.274s (step 275/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6696\n",
+      "-----\n",
+      "t = 0.275s (step 276/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6696\n",
+      "-----\n",
+      "t = 0.276s (step 277/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6681\n",
+      "-----\n",
+      "t = 0.277s (step 278/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6679\n",
+      "-----\n",
+      "t = 0.278s (step 279/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2965 / 0.6688\n",
+      "-----\n",
+      "t = 0.279s (step 280/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2966 / 0.6691\n",
+      "-----\n",
+      "t = 0.28s (step 281/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.297 / 0.6703\n",
+      "-----\n",
+      "t = 0.281s (step 282/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.01012 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6706\n",
+      "-----\n",
+      "t = 0.282s (step 283/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2994 / 0.6703\n",
+      "-----\n",
+      "t = 0.283s (step 284/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6698\n",
+      "-----\n",
+      "t = 0.284s (step 285/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00995 [m]\n",
+      "      beta_p/li = 0.2995 / 0.6697\n",
+      "-----\n",
+      "t = 0.285s (step 286/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6696\n",
+      "-----\n",
+      "t = 0.286s (step 287/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.299 / 0.6696\n",
+      "-----\n",
+      "t = 0.287s (step 288/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2963 / 0.6827\n",
+      "-----\n",
+      "t = 0.288s (step 289/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.285  1.357  0.503 -1.249]\n",
+      "      Z position = 0.00986 [m]\n",
+      "      beta_p/li = 0.3124 / 0.6589\n",
+      "-----\n",
+      "t = 0.289s (step 290/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.348  0.5   -1.247]\n",
+      "      Z position = 0.00989 [m]\n",
+      "      beta_p/li = 0.2972 / 0.6633\n",
+      "-----\n",
+      "t = 0.29s (step 291/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.245]\n",
+      "      Z position = 0.00987 [m]\n",
+      "      beta_p/li = 0.2921 / 0.6665\n",
+      "-----\n",
+      "t = 0.291s (step 292/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.347  0.499 -1.244]\n",
+      "      Z position = 0.01018 [m]\n",
+      "      beta_p/li = 0.2917 / 0.6694\n",
+      "-----\n",
+      "t = 0.292s (step 293/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.499 -1.244]\n",
+      "      Z position = 0.01024 [m]\n",
+      "      beta_p/li = 0.2939 / 0.6703\n",
+      "-----\n",
+      "t = 0.293s (step 294/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.5   -1.245]\n",
+      "      Z position = 0.01016 [m]\n",
+      "      beta_p/li = 0.2962 / 0.6708\n",
+      "-----\n",
+      "t = 0.294s (step 295/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.501 -1.245]\n",
+      "      Z position = 0.01017 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6711\n",
+      "-----\n",
+      "t = 0.295s (step 296/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6705\n",
+      "-----\n",
+      "t = 0.296s (step 297/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6699\n",
+      "-----\n",
+      "t = 0.297s (step 298/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00993 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6698\n",
+      "-----\n",
+      "t = 0.298s (step 299/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6696\n",
+      "-----\n",
+      "t = 0.299s (step 300/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6696\n",
+      "-----\n",
+      "t = 0.3s (step 301/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6695\n",
+      "-----\n",
+      "t = 0.301s (step 302/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6682\n",
+      "-----\n",
+      "t = 0.302s (step 303/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6679\n",
+      "-----\n",
+      "t = 0.303s (step 304/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2964 / 0.6688\n",
+      "-----\n",
+      "t = 0.304s (step 305/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2945 / 0.6808\n",
+      "-----\n",
+      "t = 0.305s (step 306/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.284  1.356  0.502 -1.248]\n",
+      "      Z position = 0.01007 [m]\n",
+      "      beta_p/li = 0.3088 / 0.6633\n",
+      "-----\n",
+      "t = 0.306s (step 307/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.00979 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6664\n",
+      "-----\n",
+      "t = 0.307s (step 308/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.246]\n",
+      "      Z position = 0.0101 [m]\n",
+      "      beta_p/li = 0.2961 / 0.6669\n",
+      "-----\n",
+      "t = 0.308s (step 309/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.348  0.5   -1.245]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2945 / 0.669\n",
+      "-----\n",
+      "t = 0.309s (step 310/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.5   -1.245]\n",
+      "      Z position = 0.01013 [m]\n",
+      "      beta_p/li = 0.2955 / 0.6697\n",
+      "-----\n",
+      "t = 0.31s (step 311/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.5   -1.245]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2966 / 0.6703\n",
+      "-----\n",
+      "t = 0.311s (step 312/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01014 [m]\n",
+      "      beta_p/li = 0.2982 / 0.6706\n",
+      "-----\n",
+      "t = 0.312s (step 313/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6703\n",
+      "-----\n",
+      "t = 0.313s (step 314/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2997 / 0.6698\n",
+      "-----\n",
+      "t = 0.314s (step 315/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2995 / 0.6697\n",
+      "-----\n",
+      "t = 0.315s (step 316/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6696\n",
+      "-----\n",
+      "t = 0.316s (step 317/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.299 / 0.6696\n",
+      "-----\n",
+      "t = 0.317s (step 318/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6695\n",
+      "-----\n",
+      "t = 0.318s (step 319/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2961 / 0.6843\n",
+      "-----\n",
+      "t = 0.319s (step 320/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.285  1.358  0.503 -1.25 ]\n",
+      "      Z position = 0.00972 [m]\n",
+      "      beta_p/li = 0.3138 / 0.66\n",
+      "-----\n",
+      "t = 0.32s (step 321/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.501 -1.248]\n",
+      "      Z position = 0.01011 [m]\n",
+      "      beta_p/li = 0.2991 / 0.663\n",
+      "-----\n",
+      "t = 0.321s (step 322/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.246]\n",
+      "      Z position = 0.00977 [m]\n",
+      "      beta_p/li = 0.2929 / 0.6651\n",
+      "-----\n",
+      "t = 0.322s (step 323/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.245]\n",
+      "      Z position = 0.01014 [m]\n",
+      "      beta_p/li = 0.2911 / 0.6674\n",
+      "-----\n",
+      "t = 0.323s (step 324/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.499 -1.244]\n",
+      "      Z position = 0.01016 [m]\n",
+      "      beta_p/li = 0.2918 / 0.6699\n",
+      "-----\n",
+      "t = 0.324s (step 325/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.5   -1.244]\n",
+      "      Z position = 0.01029 [m]\n",
+      "      beta_p/li = 0.2945 / 0.6715\n",
+      "-----\n",
+      "t = 0.325s (step 326/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.501 -1.245]\n",
+      "      Z position = 0.01023 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6714\n",
+      "-----\n",
+      "t = 0.326s (step 327/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2997 / 0.6706\n",
+      "-----\n",
+      "t = 0.327s (step 328/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.3003 / 0.6698\n",
+      "-----\n",
+      "t = 0.328s (step 329/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00991 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6699\n",
+      "-----\n",
+      "t = 0.329s (step 330/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6696\n",
+      "-----\n",
+      "t = 0.33s (step 331/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.247]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.2994 / 0.6697\n",
+      "-----\n",
+      "t = 0.331s (step 332/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6695\n",
+      "-----\n",
+      "t = 0.332s (step 333/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00995 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6696\n",
+      "-----\n",
+      "t = 0.333s (step 334/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6695\n",
+      "-----\n",
+      "t = 0.334s (step 335/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6695\n",
+      "-----\n",
+      "t = 0.335s (step 336/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.501 -1.247]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.296 / 0.6845\n",
+      "-----\n",
+      "t = 0.336s (step 337/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.285  1.358  0.503 -1.25 ]\n",
+      "      Z position = 0.00968 [m]\n",
+      "      beta_p/li = 0.3138 / 0.6598\n",
+      "-----\n",
+      "t = 0.337s (step 338/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.501 -1.248]\n",
+      "      Z position = 0.01016 [m]\n",
+      "      beta_p/li = 0.2991 / 0.6625\n",
+      "-----\n",
+      "t = 0.338s (step 339/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.246]\n",
+      "      Z position = 0.00976 [m]\n",
+      "      beta_p/li = 0.2923 / 0.6655\n",
+      "-----\n",
+      "t = 0.339s (step 340/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.499 -1.245]\n",
+      "      Z position = 0.01015 [m]\n",
+      "      beta_p/li = 0.2911 / 0.6674\n",
+      "-----\n",
+      "t = 0.34s (step 341/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.499 -1.244]\n",
+      "      Z position = 0.01018 [m]\n",
+      "      beta_p/li = 0.2918 / 0.67\n",
+      "-----\n",
+      "t = 0.341s (step 342/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.5   -1.245]\n",
+      "      Z position = 0.01026 [m]\n",
+      "      beta_p/li = 0.2945 / 0.6725\n",
+      "-----\n",
+      "t = 0.342s (step 343/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.0103 [m]\n",
+      "      beta_p/li = 0.2988 / 0.671\n",
+      "-----\n",
+      "t = 0.343s (step 344/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.246]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.2999 / 0.6703\n",
+      "-----\n",
+      "t = 0.344s (step 345/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.501 -1.247]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6696\n",
+      "-----\n",
+      "t = 0.345s (step 346/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.247]\n",
+      "      Z position = 0.00993 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6697\n",
+      "-----\n",
+      "t = 0.346s (step 347/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.247]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2994 / 0.6697\n",
+      "-----\n",
+      "t = 0.347s (step 348/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.501 -1.247]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6696\n",
+      "-----\n",
+      "t = 0.348s (step 349/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.299 / 0.6696\n",
+      "-----\n",
+      "t = 0.349s (step 350/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6695\n",
+      "-----\n",
+      "t = 0.35s (step 351/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6695\n",
+      "-----\n",
+      "t = 0.351s (step 352/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6694\n",
+      "-----\n",
+      "t = 0.352s (step 353/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.501 -1.247]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2958 / 0.685\n",
+      "-----\n",
+      "t = 0.353s (step 354/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.286  1.358  0.503 -1.251]\n",
+      "      Z position = 0.00964 [m]\n",
+      "      beta_p/li = 0.3143 / 0.6594\n",
+      "-----\n",
+      "t = 0.354s (step 355/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.501 -1.248]\n",
+      "      Z position = 0.0102 [m]\n",
+      "      beta_p/li = 0.299 / 0.6621\n",
+      "-----\n",
+      "t = 0.355s (step 356/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.346  0.5   -1.246]\n",
+      "      Z position = 0.00973 [m]\n",
+      "      beta_p/li = 0.2919 / 0.6655\n",
+      "-----\n",
+      "t = 0.356s (step 357/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.346  0.5   -1.245]\n",
+      "      Z position = 0.01017 [m]\n",
+      "      beta_p/li = 0.2909 / 0.6673\n",
+      "-----\n",
+      "t = 0.357s (step 358/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.348  0.5   -1.245]\n",
+      "      Z position = 0.01015 [m]\n",
+      "      beta_p/li = 0.2914 / 0.6695\n",
+      "-----\n",
+      "t = 0.358s (step 359/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.501 -1.245]\n",
+      "      Z position = 0.01023 [m]\n",
+      "      beta_p/li = 0.2938 / 0.672\n",
+      "-----\n",
+      "t = 0.359s (step 360/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.502 -1.245]\n",
+      "      Z position = 0.01026 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6719\n",
+      "-----\n",
+      "t = 0.36s (step 361/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.503 -1.246]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.3001 / 0.6706\n",
+      "-----\n",
+      "t = 0.361s (step 362/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.504 -1.246]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.3004 / 0.6695\n",
+      "-----\n",
+      "t = 0.362s (step 363/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.504 -1.246]\n",
+      "      Z position = 0.00991 [m]\n",
+      "      beta_p/li = 0.2996 / 0.6696\n",
+      "-----\n",
+      "t = 0.363s (step 364/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.504 -1.246]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6695\n",
+      "-----\n",
+      "t = 0.364s (step 365/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.505 -1.246]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6694\n",
+      "-----\n",
+      "t = 0.365s (step 366/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.505 -1.246]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6682\n",
+      "-----\n",
+      "t = 0.366s (step 367/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.506 -1.246]\n",
+      "      Z position = 0.00995 [m]\n",
+      "      beta_p/li = 0.2973 / 0.6679\n",
+      "-----\n",
+      "t = 0.367s (step 368/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.506 -1.246]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2962 / 0.6681\n",
+      "-----\n",
+      "t = 0.368s (step 369/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.506 -1.246]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2957 / 0.6688\n",
+      "-----\n",
+      "t = 0.369s (step 370/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.507 -1.246]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.296 / 0.6701\n",
+      "-----\n",
+      "t = 0.37s (step 371/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.508 -1.246]\n",
+      "      Z position = 0.01006 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6701\n",
+      "-----\n",
+      "t = 0.371s (step 372/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.509 -1.246]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2984 / 0.671\n",
+      "-----\n",
+      "t = 0.372s (step 373/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.51  -1.247]\n",
+      "      Z position = 0.01008 [m]\n",
+      "      beta_p/li = 0.2998 / 0.6694\n",
+      "-----\n",
+      "t = 0.373s (step 374/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.511 -1.247]\n",
+      "      Z position = 0.00985 [m]\n",
+      "      beta_p/li = 0.299 / 0.6683\n",
+      "-----\n",
+      "t = 0.374s (step 375/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.511 -1.246]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6679\n",
+      "-----\n",
+      "t = 0.375s (step 376/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.511 -1.246]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2965 / 0.6678\n",
+      "-----\n",
+      "t = 0.376s (step 377/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.512 -1.246]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.2956 / 0.6688\n",
+      "-----\n",
+      "t = 0.377s (step 378/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.513 -1.246]\n",
+      "      Z position = 0.01007 [m]\n",
+      "      beta_p/li = 0.296 / 0.6701\n",
+      "-----\n",
+      "t = 0.378s (step 379/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.514 -1.246]\n",
+      "      Z position = 0.01007 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6706\n",
+      "-----\n",
+      "t = 0.379s (step 380/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.515 -1.247]\n",
+      "      Z position = 0.01007 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6712\n",
+      "-----\n",
+      "t = 0.38s (step 381/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.352  0.516 -1.247]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.3003 / 0.6701\n",
+      "-----\n",
+      "t = 0.381s (step 382/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.517 -1.247]\n",
+      "      Z position = 0.00988 [m]\n",
+      "      beta_p/li = 0.3001 / 0.67\n",
+      "-----\n",
+      "t = 0.382s (step 383/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.517 -1.247]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.3 / 0.6684\n",
+      "-----\n",
+      "t = 0.383s (step 384/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.518 -1.247]\n",
+      "      Z position = 0.00993 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6671\n",
+      "-----\n",
+      "t = 0.384s (step 385/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.518 -1.247]\n",
+      "      Z position = 0.00991 [m]\n",
+      "      beta_p/li = 0.2962 / 0.6673\n",
+      "-----\n",
+      "t = 0.385s (step 386/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.519 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.295 / 0.6678\n",
+      "-----\n",
+      "t = 0.386s (step 387/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.278  1.348  0.52  -1.246]\n",
+      "      Z position = 0.01006 [m]\n",
+      "      beta_p/li = 0.2947 / 0.6701\n",
+      "-----\n",
+      "t = 0.387s (step 388/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.521 -1.246]\n",
+      "      Z position = 0.01014 [m]\n",
+      "      beta_p/li = 0.2966 / 0.6707\n",
+      "-----\n",
+      "t = 0.388s (step 389/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.522 -1.247]\n",
+      "      Z position = 0.0101 [m]\n",
+      "      beta_p/li = 0.2984 / 0.6722\n",
+      "-----\n",
+      "t = 0.389s (step 390/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.523 -1.247]\n",
+      "      Z position = 0.01018 [m]\n",
+      "      beta_p/li = 0.3012 / 0.6702\n",
+      "-----\n",
+      "t = 0.39s (step 391/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.351  0.524 -1.248]\n",
+      "      Z position = 0.00979 [m]\n",
+      "      beta_p/li = 0.3005 / 0.6703\n",
+      "-----\n",
+      "t = 0.391s (step 392/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.525 -1.248]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.3007 / 0.6702\n",
+      "-----\n",
+      "t = 0.392s (step 393/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.525 -1.248]\n",
+      "      Z position = 0.00993 [m]\n",
+      "      beta_p/li = 0.3005 / 0.6685\n",
+      "-----\n",
+      "t = 0.393s (step 394/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.526 -1.248]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6669\n",
+      "-----\n",
+      "t = 0.394s (step 395/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.526 -1.247]\n",
+      "      Z position = 0.00987 [m]\n",
+      "      beta_p/li = 0.2963 / 0.6669\n",
+      "-----\n",
+      "t = 0.395s (step 396/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.527 -1.246]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2948 / 0.6682\n",
+      "-----\n",
+      "t = 0.396s (step 397/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.527 -1.246]\n",
+      "      Z position = 0.01008 [m]\n",
+      "      beta_p/li = 0.2949 / 0.6688\n",
+      "-----\n",
+      "t = 0.397s (step 398/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.3 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.528 -1.246]\n",
+      "      Z position = 0.0102 [m]\n",
+      "      beta_p/li = 0.2956 / 0.6705\n",
+      "-----\n",
+      "t = 0.398s (step 399/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.35   0.529 -1.247]\n",
+      "      Z position = 0.01006 [m]\n",
+      "      beta_p/li = 0.2975 / 0.6721\n",
+      "-----\n",
+      "t = 0.399s (step 400/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.531 -1.247]\n",
+      "      Z position = 0.0102 [m]\n",
+      "      beta_p/li = 0.3006 / 0.6711\n",
+      "-----\n",
+      "t = 0.4s (step 401/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.531 -1.247]\n",
+      "      Z position = 0.00988 [m]\n",
+      "      beta_p/li = 0.3012 / 0.6705\n",
+      "-----\n",
+      "t = 0.401s (step 402/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.532 -1.248]\n",
+      "      Z position = 0.00995 [m]\n",
+      "      beta_p/li = 0.3013 / 0.6694\n",
+      "-----\n",
+      "t = 0.402s (step 403/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.532 -1.247]\n",
+      "      Z position = 0.00988 [m]\n",
+      "      beta_p/li = 0.3001 / 0.6686\n",
+      "-----\n",
+      "t = 0.403s (step 404/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.533 -1.247]\n",
+      "      Z position = 0.00995 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6688\n",
+      "-----\n",
+      "t = 0.404s (step 405/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.533 -1.247]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.298 / 0.668\n",
+      "-----\n",
+      "t = 0.405s (step 406/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.348  0.534 -1.247]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2968 / 0.6678\n",
+      "-----\n",
+      "t = 0.406s (step 407/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.348  0.534 -1.246]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2959 / 0.6688\n",
+      "-----\n",
+      "t = 0.407s (step 408/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.535 -1.246]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2962 / 0.6705\n",
+      "-----\n",
+      "t = 0.408s (step 409/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.536 -1.247]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.298 / 0.6719\n",
+      "-----\n",
+      "t = 0.409s (step 410/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.538 -1.247]\n",
+      "      Z position = 0.01017 [m]\n",
+      "      beta_p/li = 0.3008 / 0.6703\n",
+      "-----\n",
+      "t = 0.41s (step 411/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.538 -1.248]\n",
+      "      Z position = 0.00987 [m]\n",
+      "      beta_p/li = 0.3006 / 0.6702\n",
+      "-----\n",
+      "t = 0.411s (step 412/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.539 -1.248]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.3006 / 0.6684\n",
+      "-----\n",
+      "t = 0.412s (step 413/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.349  0.539 -1.248]\n",
+      "      Z position = 0.0099 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6682\n",
+      "-----\n",
+      "t = 0.413s (step 414/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.54  -1.247]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2975 / 0.669\n",
+      "-----\n",
+      "t = 0.414s (step 415/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.541 -1.247]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6693\n",
+      "-----\n",
+      "t = 0.415s (step 416/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.541 -1.247]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6698\n",
+      "-----\n",
+      "t = 0.416s (step 417/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.542 -1.247]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6691\n",
+      "-----\n",
+      "t = 0.417s (step 418/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.543 -1.247]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6694\n",
+      "-----\n",
+      "t = 0.418s (step 419/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.544 -1.247]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2982 / 0.67\n",
+      "-----\n",
+      "t = 0.419s (step 420/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.545 -1.248]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6692\n",
+      "-----\n",
+      "t = 0.42s (step 421/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.545 -1.248]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2985 / 0.6686\n",
+      "-----\n",
+      "t = 0.421s (step 422/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.546 -1.247]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6691\n",
+      "-----\n",
+      "t = 0.422s (step 423/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.547 -1.247]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6693\n",
+      "-----\n",
+      "t = 0.423s (step 424/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.547 -1.247]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6694\n",
+      "-----\n",
+      "t = 0.424s (step 425/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.548 -1.247]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6702\n",
+      "-----\n",
+      "t = 0.425s (step 426/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.549 -1.248]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.299 / 0.6714\n",
+      "-----\n",
+      "t = 0.426s (step 427/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.55  -1.248]\n",
+      "      Z position = 0.01013 [m]\n",
+      "      beta_p/li = 0.3008 / 0.6703\n",
+      "-----\n",
+      "t = 0.427s (step 428/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.551 -1.248]\n",
+      "      Z position = 0.00985 [m]\n",
+      "      beta_p/li = 0.3006 / 0.6699\n",
+      "-----\n",
+      "t = 0.428s (step 429/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.552 -1.249]\n",
+      "      Z position = 0.00998 [m]\n",
+      "      beta_p/li = 0.3004 / 0.6694\n",
+      "-----\n",
+      "t = 0.429s (step 430/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.552 -1.248]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.2996 / 0.668\n",
+      "-----\n",
+      "t = 0.43s (step 431/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.552 -1.248]\n",
+      "      Z position = 0.00997 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6677\n",
+      "-----\n",
+      "t = 0.431s (step 432/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.553 -1.248]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2964 / 0.6675\n",
+      "-----\n",
+      "t = 0.432s (step 433/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.7 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.349  0.553 -1.247]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2954 / 0.6666\n",
+      "-----\n",
+      "t = 0.433s (step 434/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.5 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.279  1.349  0.554 -1.246]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2939 / 0.6688\n",
+      "-----\n",
+      "t = 0.434s (step 435/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.28   1.35   0.555 -1.247]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2949 / 0.6714\n",
+      "-----\n",
+      "t = 0.435s (step 436/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.4 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.353  0.556 -1.247]\n",
+      "      Z position = 0.01018 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6724\n",
+      "-----\n",
+      "t = 0.436s (step 437/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.6 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.355  0.558 -1.248]\n",
+      "      Z position = 0.01014 [m]\n",
+      "      beta_p/li = 0.3013 / 0.6707\n",
+      "-----\n",
+      "t = 0.437s (step 438/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.354  0.559 -1.249]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.3014 / 0.6701\n",
+      "-----\n",
+      "t = 0.438s (step 439/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.559 -1.249]\n",
+      "      Z position = 0.00988 [m]\n",
+      "      beta_p/li = 0.3009 / 0.67\n",
+      "-----\n",
+      "t = 0.439s (step 440/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.56  -1.249]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.3006 / 0.6694\n",
+      "-----\n",
+      "t = 0.44s (step 441/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.56  -1.249]\n",
+      "      Z position = 0.00985 [m]\n",
+      "      beta_p/li = 0.2997 / 0.67\n",
+      "-----\n",
+      "t = 0.441s (step 442/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.561 -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.3 / 0.6696\n",
+      "-----\n",
+      "t = 0.442s (step 443/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.561 -1.248]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.2995 / 0.6683\n",
+      "-----\n",
+      "t = 0.443s (step 444/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.561 -1.248]\n",
+      "      Z position = 0.00996 [m]\n",
+      "      beta_p/li = 0.298 / 0.669\n",
+      "-----\n",
+      "t = 0.444s (step 445/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.2 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.562 -1.248]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6697\n",
+      "-----\n",
+      "t = 0.445s (step 446/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.563 -1.248]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2984 / 0.6696\n",
+      "-----\n",
+      "t = 0.446s (step 447/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.563 -1.248]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2985 / 0.6696\n",
+      "-----\n",
+      "t = 0.447s (step 448/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.564 -1.248]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6695\n",
+      "-----\n",
+      "t = 0.448s (step 449/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.565 -1.248]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6696\n",
+      "-----\n",
+      "t = 0.449s (step 450/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.565 -1.248]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6696\n",
+      "-----\n",
+      "t = 0.45s (step 451/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.566 -1.248]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2988 / 0.6696\n",
+      "-----\n",
+      "t = 0.451s (step 452/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.567 -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6696\n",
+      "-----\n",
+      "t = 0.452s (step 453/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.567 -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6696\n",
+      "-----\n",
+      "t = 0.453s (step 454/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.568 -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6696\n",
+      "-----\n",
+      "t = 0.454s (step 455/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.568 -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.299 / 0.6699\n",
+      "-----\n",
+      "t = 0.455s (step 456/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.569 -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6697\n",
+      "-----\n",
+      "t = 0.456s (step 457/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.57  -1.249]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6697\n",
+      "-----\n",
+      "t = 0.457s (step 458/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.57  -1.249]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6686\n",
+      "-----\n",
+      "t = 0.458s (step 459/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.57  -1.249]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.298 / 0.6686\n",
+      "-----\n",
+      "t = 0.459s (step 460/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.57  -1.249]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6691\n",
+      "-----\n",
+      "t = 0.46s (step 461/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.35   0.571 -1.249]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2974 / 0.6693\n",
+      "-----\n",
+      "t = 0.461s (step 462/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.571 -1.249]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6694\n",
+      "-----\n",
+      "t = 0.462s (step 463/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.572 -1.249]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.298 / 0.67\n",
+      "-----\n",
+      "t = 0.463s (step 464/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.8 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.572 -1.249]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2987 / 0.671\n",
+      "-----\n",
+      "t = 0.464s (step 465/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.573 -1.25 ]\n",
+      "      Z position = 0.0101 [m]\n",
+      "      beta_p/li = 0.3002 / 0.6695\n",
+      "-----\n",
+      "t = 0.465s (step 466/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.573 -1.25 ]\n",
+      "      Z position = 0.0099 [m]\n",
+      "      beta_p/li = 0.2995 / 0.6707\n",
+      "-----\n",
+      "t = 0.466s (step 467/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.573 -1.25 ]\n",
+      "      Z position = 0.01009 [m]\n",
+      "      beta_p/li = 0.3005 / 0.6689\n",
+      "-----\n",
+      "t = 0.467s (step 468/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00989 [m]\n",
+      "      beta_p/li = 0.2989 / 0.6689\n",
+      "-----\n",
+      "t = 0.468s (step 469/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2983 / 0.6698\n",
+      "-----\n",
+      "t = 0.469s (step 470/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6689\n",
+      "-----\n",
+      "t = 0.47s (step 471/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.01 [m]\n",
+      "      beta_p/li = 0.298 / 0.6694\n",
+      "-----\n",
+      "t = 0.471s (step 472/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6699\n",
+      "-----\n",
+      "t = 0.472s (step 473/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6689\n",
+      "-----\n",
+      "t = 0.473s (step 474/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.298 / 0.6699\n",
+      "-----\n",
+      "t = 0.474s (step 475/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.573 -1.25 ]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2987 / 0.6689\n",
+      "-----\n",
+      "t = 0.475s (step 476/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6699\n",
+      "-----\n",
+      "t = 0.476s (step 477/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.574 -1.25 ]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6689\n",
+      "-----\n",
+      "t = 0.477s (step 478/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6699\n",
+      "-----\n",
+      "t = 0.478s (step 479/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.574 -1.25 ]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6689\n",
+      "-----\n",
+      "t = 0.479s (step 480/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 758.9 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6699\n",
+      "-----\n",
+      "t = 0.48s (step 481/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.574 -1.25 ]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2986 / 0.6702\n",
+      "-----\n",
+      "t = 0.481s (step 482/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.574 -1.251]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6687\n",
+      "-----\n",
+      "t = 0.482s (step 483/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00994 [m]\n",
+      "      beta_p/li = 0.2981 / 0.669\n",
+      "-----\n",
+      "t = 0.483s (step 484/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6697\n",
+      "-----\n",
+      "t = 0.484s (step 485/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.573 -1.251]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2983 / 0.669\n",
+      "-----\n",
+      "t = 0.485s (step 486/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.351  0.573 -1.25 ]\n",
+      "      Z position = 0.00999 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6698\n",
+      "-----\n",
+      "t = 0.486s (step 487/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.573 -1.251]\n",
+      "      Z position = 0.01003 [m]\n",
+      "      beta_p/li = 0.2984 / 0.6704\n",
+      "-----\n",
+      "t = 0.487s (step 488/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.352  0.573 -1.251]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6684\n",
+      "-----\n",
+      "t = 0.488s (step 489/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.573 -1.251]\n",
+      "      Z position = 0.00993 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6691\n",
+      "-----\n",
+      "t = 0.489s (step 490/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.573 -1.251]\n",
+      "      Z position = 0.01004 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6692\n",
+      "-----\n",
+      "t = 0.49s (step 491/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.573 -1.251]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6693\n",
+      "-----\n",
+      "t = 0.491s (step 492/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.573 -1.251]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.2977 / 0.6694\n",
+      "-----\n",
+      "t = 0.492s (step 493/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.573 -1.251]\n",
+      "      Z position = 0.01001 [m]\n",
+      "      beta_p/li = 0.2979 / 0.6694\n",
+      "-----\n",
+      "t = 0.493s (step 494/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.573 -1.251]\n",
+      "      Z position = 0.01002 [m]\n",
+      "      beta_p/li = 0.298 / 0.6706\n",
+      "-----\n",
+      "t = 0.494s (step 495/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.573 -1.251]\n",
+      "      Z position = 0.01006 [m]\n",
+      "      beta_p/li = 0.2993 / 0.6683\n",
+      "-----\n",
+      "t = 0.495s (step 496/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.351  0.573 -1.251]\n",
+      "      Z position = 0.0099 [m]\n",
+      "      beta_p/li = 0.2976 / 0.6692\n",
+      "-----\n",
+      "t = 0.496s (step 497/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.0 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.573 -1.251]\n",
+      "      Z position = 0.01005 [m]\n",
+      "      beta_p/li = 0.2978 / 0.6706\n",
+      "-----\n",
+      "t = 0.497s (step 498/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.282  1.353  0.573 -1.251]\n",
+      "      Z position = 0.01006 [m]\n",
+      "      beta_p/li = 0.2992 / 0.6688\n",
+      "-----\n",
+      "t = 0.498s (step 499/499)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Ip = 759.1 [kA]\n",
+      "      Shape parameters ['Rin', 'Rout', 'Rx', 'Zx'] = [ 0.281  1.352  0.572 -1.251]\n",
+      "      Z position = 0.00992 [m]\n",
+      "      beta_p/li = 0.2981 / 0.6685\n"
+     ]
+    }
+   ],
+   "source": [
+    "# RUN FPDT SIMULATION\n",
+    "for i, t in enumerate(times[0:-1]):\n",
+    "    print(\"-----\")\n",
+    "    print(f\"t = {np.round(t,5)}s (step {i+1}/{n-1})\")\n",
+    "    \n",
+    "    # start timer\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    # initialise any historical quantities for PCS PID controllers\n",
+    "    if i == 0:\n",
+    "        ip_hist_prev = 0.0\n",
+    "        ip_err_prev = 0.0\n",
+    "        T_err_prev = np.zeros(len(ctrl_targets))\n",
+    "        T_hist_prev = np.zeros(len(ctrl_targets))\n",
+    "        I_approved_prev = eq.tokamak.getCurrentsVec()[0:11]  # must use starting currents here\n",
+    "        V_approved_prev = np.zeros(len(ctrl_coils))\n",
+    "        zipv_meas = 0.0\n",
+    "    else:\n",
+    "        ip_hist_prev=ip_hist[i-1].copy()                              # integral term from FB PID Plasma controller at prior step\n",
+    "        ip_err_prev=ip_err[i-1].copy()                                # error term from FB PID Plasma controller at prior step\n",
+    "        T_err_prev=T_err[:,i-1].copy()                                # proportional term from FB PID Shape controller at prior step\n",
+    "        T_hist_prev=T_hist[:,i-1].copy()                              # integral term from FB PID Shape controller at prior step\n",
+    "        I_approved_prev=I_approved[:,i-1].copy()                      # approved PF coil currents from prior step (ctrl_coils only)\n",
+    "        V_approved_prev=V_approved[0:-1,i-1].copy()                   # approved PF coil voltages from prior step (ctrl_coils only)\n",
+    "        zipv_meas = ((z_current[-1]-z_current[-2])/dt)*dynamic_ip[i]  # rate of change of vertical plasma position \n",
+    "    \n",
+    "    # call the PCS class to attain PF coil voltages (on ctrl_coils and vertical coil)\n",
+    "    V_approved[:,i], ip_hist[i], ip_err[i], T_err[:,i], T_hist[:,i], I_approved[:,i], coil_resists[:,i] = PCS.calculate_ctrl_voltages(\n",
+    "        t=t,                                        # current simulation time\n",
+    "        dt=dt_PCS,                                  # PCS time step\n",
+    "        dt_simulator=dt,                            # simulator (solver) time step\n",
+    "        ip_meas=dynamic_ip[i],                      # measured plasma current\n",
+    "        ip_hist_prev=ip_hist_prev,                  # plasma controller integral term history\n",
+    "        ip_err_prev=ip_err_prev,                    # plasma controller error term history (for derivative term)\n",
+    "        T_meas=dynamic_shape_targets[:,i].copy(),   # measured shape parameters\n",
+    "        T_err_prev=T_err_prev,                      # shape controller proportional term history\n",
+    "        T_hist_prev=T_hist_prev,                    # shape controller integral term history\n",
+    "        I_approved_prev=I_approved_prev,            # approved PF currents from prior timestep\n",
+    "        I_meas=dynamic_currents[0:11,i].copy(),     # measured PF coil currents\n",
+    "        V_approved_prev=V_approved_prev,            # approved PF voltages from prior timestep\n",
+    "        zip_meas=z_current[i]*dynamic_ip[i],        # measured vertical position x measured plasma current\n",
+    "        zipv_meas=zipv_meas,                        # derivative of above\n",
+    "        active_coil_resists=tokamak.coil_resist[0:12].copy(),    # PF coil resistances (these are constant)\n",
+    "        verbose=False,                              # print some output?\n",
+    "    )\n",
+    "\n",
+    "    # prescribe the end-of-step physical profile targets. The solver converts\n",
+    "    # these beta_p/li values to Lao alpha/beta coefficients internally.\n",
+    "    profile_params = {\n",
+    "        \"betap\": float(np.interp(t + dt, profile_betap_ref[\"times\"], profile_betap_ref[\"vals\"])),\n",
+    "        \"li\": float(np.interp(t + dt, profile_li_ref[\"times\"], profile_li_ref[\"vals\"])),\n",
+    "    }\n",
+    "\n",
+    "    # run freegsnke over the time step with the calculated voltages\n",
+    "    stepping.nlstepper(\n",
+    "        plasma_resistivity=1e-7,                          # assign plasma resistivity (chosen to be constant here)\n",
+    "        active_voltage_vec=V_approved[:,i],               # assign approved PF coil voltages from the PCS\n",
+    "        profiles_parameters=profile_params,               # assign physical profile targets\n",
+    "        profile_constraint_options=profile_constraint_options,  # options for fitting beta_p/li to Lao alpha/beta\n",
+    "        custom_active_coil_resistances=coil_resists[:,i], # assign active coil resistances from PCS (tells solver if any coils are switched off)\n",
+    "        linear_only=True,                                 # linear or nonlinear solve?\n",
+    "        target_relative_tol_currents=1e-2,                # relative tolerance in the currents required for convergence\n",
+    "        target_relative_tol_GS=1e-2,                      # relative tolerance in the plasma flux required for convergence\n",
+    "        working_relative_tol_GS=(1e-2)/2,                 # tolerance used when solving GS equation, expressed in terms of the change in the plasma flux due to one timestep of evolution (must be smaller tolerance above)\n",
+    "        verbose=False,                                    # print some output?\n",
+    "        relinearise_threshold=threshold,                  # if the relative jtor norm change from last linearisation is above threshold, relinearise around current equilibrium\n",
+    "        no_GS=False,                                      # do not solve GS at each time?\n",
+    "        )\n",
+    "\n",
+    "    # stop timer\n",
+    "    end_time = time.time()\n",
+    "\n",
+    "    # extract and store relevant data\n",
+    "    dynamic_psi[:,:,i+1] = stepping.eq1.psi()\n",
+    "    dynamic_limiter_flag[i+1] = stepping.eq1._profiles.flag_limiter\n",
+    "    dynamic_psi_boundary[i+1] = stepping.eq1._profiles.psi_bndry\n",
+    "    dynamic_xpts.append(stepping.eq1.xpt)\n",
+    "    dynamic_opts.append(stepping.eq1.opt)\n",
+    "    dynamic_currents[:,i+1] = stepping.currents_vec[:-1].copy()\n",
+    "    dynamic_ip[i+1] = stepping.currents_vec[-1] * stepping.plasma_norm_factor\n",
+    "    dynamic_shape_targets[:,i+1] = plasma_descriptors(stepping.eq1)\n",
+    "    dynamic_timings[i] = end_time - start_time\n",
+    "    dynamic_triangularity[i+1] = stepping.eq1.triangularity()\n",
+    "    dynamic_betap[i+1] = stepping.eq1.poloidalBeta1()\n",
+    "    dynamic_li[i+1] = stepping.eq1.internalInductance2()\n",
+    "    profile_betap_target[i+1] = profile_params[\"betap\"]\n",
+    "    profile_li_target[i+1] = profile_params[\"li\"]\n",
+    "    z_current.append(stepping.eq1.Zcurrent())\n",
+    "    dynamic_jtor_norm.append(stepping.relinearise_criteria)\n",
+    "\n",
+    "    # print some stuff to track solve\n",
+    "    print(f\"      Ip = {np.round(dynamic_ip[i+1]/1000,1)} [kA]\")\n",
+    "    print(f\"      Shape parameters {ctrl_targets} = {np.round(dynamic_shape_targets[:,i+1],3)}\")\n",
+    "    print(f\"      Z position = {np.round(z_current[i+1],5)} [m]\")\n",
+    "    print(f\"      beta_p/li = {dynamic_betap[i+1]:.4g} / {dynamic_li[i+1]:.4g}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot some results\n",
+    "\n",
+    "Let's now plot some of the output. We can compare the evolution of the controlled parameters (plasma current, shape parameters, and vertical position) against their FB reference waveforms. In these plots:\n",
+    "- the black dashed indicated the FB reference waveform. \n",
+    "- the solid blue the simulated quantity.\n",
+    "- green background shading indicates when FB control is ON. \n",
+    "- yellow background shading indicates when FF control is ON (not used). \n",
+    "- white background shading indicates no control is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:54.579262Z",
+     "iopub.status.busy": "2026-06-21T18:16:54.579146Z",
+     "iopub.status.idle": "2026-06-21T18:16:54.792231Z",
+     "shell.execute_reply": "2026-06-21T18:16:54.791934Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7gAAAHaCAYAAAAqmuUjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAMTgAADE4Bf3eMIwABAABJREFUeJzsnQd4U1Ubx9/SUvbee4PsvUFERBBkCSoqfqAiAuLCgQMHCogLRUUFQVBARBmKqGwUlL333psCHbSlg+Z7/m9ybm9ubtokTZqkfX/Pk6dN7jr33JOb+z/vCrFYLBYSBEEQBEEQBEEQhCAnh78bIAiCIAiCIAiCIAjeQASuIAiCIAiCIAiCkCUQgSsIgiAIgiAIgiBkCUTgCoIgCIIgCIIgCFkCEbiCIAiCIAiCIAhClkAEriAIgiAIgiAIgpAlEIErCIIgCIIgCIIgZAlE4AqCIAhZlpCQEFq5cqVP9n3PPffQe++955V9zZw5k8qXL0+ZzcmTJ6l9+/ZUsGBBatOmDZ0+fZry589Px48f92u7BEEQBMFTROAKgiAEMXv27KH+/ftTmTJlWJhUrlyZHnroIdq+fXumHP+OO+6g0aNHe32/gwYNogEDBrgkYPPkycPnXqxYMerQoQP9+++/lBn89ddf9Oabb2bKsSA0c+TIweeJV7ly5ejJJ5+kyMjIDO33/fffpyJFivB+1q9fTxUrVqQbN25Q1apVM9zmOXPmaO3FC+3PnTu39r5u3brkD3w1ZgVBEITAQASuIAhCkPL3339TixYtqFSpUrRhwwaKiYmhnTt3UufOnemXX36h7MLvv//OouzMmTNUv3596t69O0VHR1NWo2zZsnyeeP3zzz/8ev75503XTUxMdGmfx44dowYNGrD49DaPPPKI1l680P5vvvlGe79v3z639peUlOT1NgqCIAhZDxG4giAIQcpTTz1F/fr1o0mTJrHlFtbMwoUL0+OPP86WOb31r169euyGir/ff/+9nYsqtsNnDRs2pAIFClCrVq1o//792jo///wzW9uwffHixemuu+7iz4cOHUrr1q2jDz/8ULPKgb1791KnTp2oRIkSVKhQIWrZsiWtXr3a5WOOHz+erX/z5s3T9gvX2fTImzcvtwni9siRI9rnBw4coLZt2/J+IICVhffo0aMUFhbG7dFz7733asLR2bmbWQLPnj3Log4uvVi/UaNGmiUdEw5NmzZlayn207NnTzpx4gR5SvXq1Xkf27Zt0yzeDzzwAA0bNoz7vVevXvz5H3/8wcfFdahZsyZ9/PHHlJKSwsuqVatGa9as0a4f+l1dG/SNGbdu3aJPPvmEateuzfvEvletWuV2+2/evEn3338/W6Jx/WvVqkWTJ0+2Wwdj+u2336auXbvyOjguRO6LL75IpUuX5vN87bXXqF27dvTOO+9o2507d44efvhh3nfJkiXZo+HKlStpjtldu3ax9R/fH1wjnNehQ4fcPi9BEAQhALAIgiAIQcfhw4ctuIUvX748zfXmz59vKVCggGXlypWW5ORky4oVKyz58uWzLFq0iJefOHGC99OpUyfL+fPnLfHx8Za+fftabr/9dl4eGxtryZkzp2XVqlX8HsvV/6BDhw6WN954w+6Ye/bs4XbFxcVZbt68aXn77bctBQsWtFy6dMmlY4KBAwdaHnnkkXT7AfvBOYGYmBjL8OHDLYULF7ZER0dryxs0aGA5cuSIJSkpyfLcc89ZKlasqG3fuXNny+uvv669P3XqlCU0NNRy4MABt84d51qjRg3LoEGDLFeuXLHcunXLsm/fPsvJkyd5+V9//WXZuXMnXwMsv/feey2tWrXS9jVjxgxLuXLlnJ6ncfmhQ4f4eI8//rjWX2FhYZbp06dbEhMTue2bN2/m9s+bN4/PfevWrZYyZcpYPv30U6fXT10b9JfZcXEtGzZsaDl48CCf48KFCy158+a1HD16NN1rhf1gf6q/vvvuO8v169d5P0uWLLGEh4dbli5dqq1fqVIlS6lSpSzr16+3pKSk8DmNGTPGUrVqVT6+Gls4b/wF+KxWrVqWF1980XLjxg0eEwMGDLDcddddTs8ZtGnThveNfsJrx44dlosXL6Z7ToIgCELgIRZcQRCEIOTy5cv8N70EQFOnTqUnnniCLaqhoaFsgcR7uIrqeeuttziOFzGSjz32GG3ZskVbljNnTraCRkRE8PI777wzzWPCSgw3acTG5sqVi61rsApu2rTJ5WO6Q+/evdnqVqNGDTp8+DD9+eefbPFTwOIHiyestYhbhTX40qVLvAwWzxkzZlBycjK/nzZtGlsEb7vtNrfOHZbSq1evcr/CQguX3zp16lClSpV4OayQsFbjGmD5u+++Sxs3bmS3clc5f/68ZmFEgitcy08//VRb3qxZM7beo82wZuNc4K4Nyy7OHVbJl19+2eHauwOO98EHH7DFFefYp08fTk41d+5ct/aDsYFrjvPBftBO9NHy5cvt1sM6rVu35vGDc/rhhx/4euL4GFuIgS5atKjddUCffvTRR5QvXz620E6YMIETjcHC7ozw8HAeF6dOneK+gvUdrv+CIAhC8CECVxAEIQiB6yVI66EdIC4Vrqh6IPaMLr+Ij1RAGMTHx7Pog6hYunQpCwSICrj4wiU6LbBvJL5CwiK46kLEwG1YifL0jukuv/76K12/fp0uXLhAK1asYEGU1nGAEpZw84XoXLx4MR97+vTp7PoN3Dl3uBvDpRaiywzEy2KSAYIefQJ3WGDsk7TAeSAZFM4VsbNfffUV70tRpUoVj669q2BSANcRrsW4puqF5FRwC3aHhIQEeumll9htGq7O2A+Sdhn7w3hOOI6aNAC4dhUqVNDewzUd7cQkgGofXMxxXdI6b7jxQ0RjAgOTRnBRR5ywIAiCEHyE+bsBgiAIgvvAWglxMGvWLLaWOgMP/xBDevAe4tNVUEYGL3j8QqjB0gbrJI5rlpwIVlKIFlhkYQXDdhAcVo9h1/BF0iMzIJDQXli6cUzEePbt29elc9cDcYv4VSR3gjVQDz5DXC8s1hDjsC7v2LGDmjRp4lafuNtn3rj2eiAWYcVesmQJ3X777Rlq68SJEzk5GF4Yy2g74oaN/WE8J8TVwsqqQDyxfpIHsbkQwMbzTmufANt8++23/D/ij9EWTIaMGzcuQ+cpCIIgZD5iwRUEQQhSpkyZwsmLRo4cyQ/9EAewsMGN84033uB1Bg8eTN999x1nXEaCICR7gpVyyJAhLh3j4sWLfAxYDlUSK/yFG6cSFHAL1hMVFcWuoRC1sbGxnAjIXWsY9guRgjb7GghcJFsaM2YMJ2tSAjW9c9cDAYvzHT58OLsz41ogaRauCwQurNNYDnELV+PMKFMDd2W47C5YsID7EaIarruuXnsjsIIiSdMrr7zCbts4R5zX2rVrHcZAemCMYH9IFAWRin42uieb8eijj7KbNI6Hfh07diy7hivuu+8+nqSA6zKOAWAVRsIyhdmYhQUXQhnnBKs4rrHZdRYEQRACHxG4giAIQQqy+CKuFW6bKBcE8YSSL3CrRXZlAHdSZJ+F8IJAe+aZZ9jNFkLAFfDAj5hN1EWFaMV+YdXq2LEjL0c8JLLNKpdQ8Pnnn3NWWnwGayesbunFChtRIgzxqtivp261rgC3Ybgqo83KPdmVczfGlGLyAEIersywYCOj8rVr13hbxMNCjOF/xM/iuvgaZK+eP38+txnXAsd89tln6bnnnvN4n8jCjKzEyk0Zlmtk7Ha3hA/ck2FhhuUUrtfIxIxY6vTAZAnidWFVx7iCwG7cuDFblgG+AyiZhfGC6wCxihhhiHCF2ZjFBAe+Q7g+iJWGm/uoUaPc7h9BEATB/4Qg05S/GyEIgiAI/gRiBiV9EMMrBA+Im8YEBSZVILwFQRAEQSy4giAIQrYG1j64bcPVWwhskBwMcbtwT4a1HBMTcHGGVVwQBEEQgAhcQRAEIdsCN2K4UT/88MMikoIAiNn33nuPXdfhorx582YuC6VcjQVBEARBXJQFQRAEQRAEQRCELIFYcAVBEARBEARBEIQsgQhcQRAEQRAEQRAEIUsgAlcQBEEQBEEQBEHIEojAFQRBEARBEARBELIEInAFQRAEQRAEQRCELIEIXEEQBEEQBEEQBCFLIAJXEARBEARBEARByBKIwBUEQRAEQRAEQRCyBCJwBUEQBEEQBEEQhCyBCFxBEARBEARBEAQhSyACVxAEQRAEQRAEQcgSiMAVBEEQBEEQBEEQsgQicAVBEARBEARBEIQsQZi/GxBo5MqVi0qUKOGVfSUkJPD+BOkrbyFjSvrK28iYyvy+unLlCu8rK+Ot31IZn9JXvkDGlfSTjKms/TsqAtcAfpDPnj1L3mDZsmXUpUsXr+wrqyN9Jf0kY0q+e9nlPlW+fHnK6njrt1R+G6SvfIGMK+knGVNZ+3dUXJQFQRAEQRAEQRCELIEIXEEQBEEQBEEQBCFL4FeBe+TIEWrTpg3VrFmTmjdvTvv27XNYZ8OGDdSoUSN+1a1bl5566inN5/rkyZN0xx13UKFChXi5nr///pvy5MmjbYtXfHx8pp2bIAiCIAiCIAiCkLn4NQYXYnXIkCE0aNAgmj9/Pv/dsmWL3ToNGzbkz3LmzEkpKSnUt29f+uqrr+iFF16gggUL0tixYykqKoreeOMNh/3XqlWLdu7c6dU2ow0Wi8Xl9W/duuXV42dlAqmvQkJCKEcOcXAQBEEQBEEQhGDCbwL38uXLtHXrVlq+fDm/h3AdMWIEHT16lKpXr66tlzdvXu3/xMREtsJCfICiRYtSu3bt2Frra3Ds06dPU1JSkltJNg4fPuzTdmUVArGvMKlSsWJFCg8P93dTBEEQBEEQBEEIZIF75swZKlOmDIWFWZsA0QoxARGpF7jKFblXr1507Ngx6t69Ow0fPtylY2D9Jk2aUGhoKD322GMub2cG2lWgQAEqVqyYJrDTIzo6mq3MQvD1Faz0V69eNR2PgiAIgiAIgiAEJkFRJqhy5cq0a9cuunHjBg0YMIAWLlxI/fv3T3MbCFuUKEB8Lv5269aNihcvTg888IDdehMnTuSXIjIyklNYm1kYYTGOjY11ud0QwmizEJx9BQsuhLfZePAXN2/e9Gt7fvvtIoWGEt17b2kKdPzdV8GC9JP0lSAImce1Q4do3WuvUa+FC6XbBSGrCdwKFSrQhQsXKDk5ma24sJjBWgYrrjPy58/PwnbOnDnpCly9NRC1kh566CFat26dg8AdOXIkv/TrGuszITYU7rMQy7AGuwpig7GNEJx9heuORGV33XWXW9c9K9fu++OPvyhnzhxBUd/Z330VLEg/SV8JgpB53Dh3ji7v2iVdLgg+xG9ZdEqWLMlW1tmzZ/P7BQsWsLg0uoMiJlfFvSIOdtGiRdSgQYN09w/xjIRQICYmhpYsWUKNGzemrAQs20ikpbJEDx482Gv7vnTpEj3++ONUtWpVTvSFPh86dCi77SoX8549e1L9+vX5heOvXr2al82cOZMtsrNmzdL2h/5HxmsFlsNaDq5fv06dO3em559/nic6sF6VKlXsMmCLJS4wSEmx8EsQBEEQBPexIFmp7flUEIQs6KI8ZcoUzpw8fvx4trjOmDGDP4dQg3jCC6Lp888/ZwsarL2dOnWiN998k9eLi4vjEkMoGwQLIATyo48+Su+//z4L5q+//pqtw9ju/vvv5zjcrMa8efMcSiTpLZCeWB7Rr7fffjs98sgjXMoJ+8DkwvTp0+ncuXMchzxs2DC+FosXL+ZtIiIieDtFpUqV6K233qIHH3wwzSRNmIiAla1Hjx40btw47fNPP/2Uevfu7XbbBd+CCQgRuIIgCILg+e+oCFxByMICF9ZH1Lk1Mm3aNO1/lBHCywxkWEZ8rRnIyIxXdgKW0++//55jheFSPXXqVBb4o0aN4lhSCN7XX3+dxT6AVfS9997jzNQQsR988AF17NiRfvzxRypSpAgLVAVEKkStAv1erlw57T3im/VAdGOfkydP5pJOZpw4cYJdxrEcYloIfCBu3aiSJTjh3Xf/odDQEHrjjduljwRBELIRLG7lhzTDwM17+ZNP0oDNm71xWYQsRlAkmQrE2beYmMR014uOTqCQkASPjlGgQLhL2ZphIUWcKBg4cCBt2rSJduzYwZMHcAGGYP3zzz85YzWsrHALb9OmDVu933nnHRa5sJ7DFbx9+/acsXr79u3UsmXLNI8L0fzEE0/QpEmTqFWrVpzlGlZfPbDMd+jQgdczA27JsNqiHjIs8HogetE+BSzy1apVS7c/BN+C32Sx4GaciIg4CguTOsuCIAjZDrHgeoWbV69SfESEd3YmZDlE4HoAxG2hQhPIl0RFvUoFC+Zyy0UZFlyIV4hbsH79ejp+/Djdc889dtscOnSIDh48yKJWL0pz5MjBib7MjgG3b4hQWICffPJJTtrVtWtXWrNmDf33338scLHs5Zdf1rZDO+BmDstw69atHfaLkk/fffedacIwcVEOTMRF2TtILLMgCEL2RFyUvdSPEssspIEIXA+tqxCgvswMjGN4AjJN62+idevWZaFr5MCBA2xBhTuyESTjgvDUW4nxQry0vkwS3Jjvu+8+fjVv3pwttnqBC2CFRZIqJMQyAuvv22+/zVmK58+fH3BZlAVzYZYjR9b2Ub5xI5Hy53f9+3f5cixNmbKV3nyzg8vbyESBIAhC9iQ7uCgnJ8CDMYRC08jBYuTfN9+kZi++SLkLF3ZpfZkoENJCfOQ8AF9aWFd9+XLFPTk9YM1FnOvKlSu1z3bu3MkJo5DYCZ/v3r1bW7bZFsfw8MMPszsz3IcRt6vQJ5FCVmT1HjcZuEWbuRCXLVuWk4ZB/JoBkduuXTu2ACObshDYZAcX5YYNv6EDB664vP7BgxE0bdoOt44hFlxBEIRsSjZwUV73+uu09ZNP3Npm5+TJFHXihMvriwVXSAsRuFkYWFj/+OMPFpewotapU4deffVVLp+Eckyw3iL+Fctq165Nn332GW+XL18+Wrt2LWdQxnqw6EIsI5EUrLXgn3/+oaZNm2plguDu/OWXX5q2A8dEkitnwB0ZIhdZmVUZIsTg6ssEofax4H+ygzCLiUlwKcY+I9ZYTBRgO0EQBCF7kR2EWVJMDCXGxLi1jdsWWesPqfuNE7IF4qIcxCAhlB64EOOlB0mlVH1aI3ANxssMJKVCTK8zPvroI36ZYWwHXI+VcFUYH+5hLVYuyn///bfT4wr+JTtYcK2Zoi0+Wz9VFHvQOEEQBCG4yQYWXBbx7v4uuum6LS7KQlqIwBUEwS0x5w33+awk4j0R/Vl9kkAQBEHIvjG4HolPN7fJDpZwwXNE4AqC4DLZwfLorhu2J27b2cESLgiCIGRPy6Mn4tPtbbJBPwqeIwJXEASXyQ6izN2YWk9icK3ZqLO2JVwQBEHIppZHD8Snu8I/O1jCBc+RJFOCILhMdsjpIBZcQRAEwWdAyGXxH1IWn+6KeLHgCl5ELLiCILhM9rDguh+D6+6zijWW2f22CYIgCMGNWHCd9IubP6bZoh8FjxGBKwiCy2SXGFx3BKtnMbhYXxSuIAhCtsM6i0pZGU+zKLvlopwNLOGC54iLsiAIPi2J4wvi4pKCPgY3O1jDBUEQhIyLP1+QfPMmpdy65ZN9SxZlwd+IwBXSrbX7zTffeKWXPvvsM7p48aLT5e+88w7dvHkzU6/Izp076aeffsrUYwYzgZD999atFCpT5hO6fj3eJ/uXGFxBEAQhq2dR/mvQIDo4d65P9i1ZlAV/IwJXCBiBO2bMGI8EbnJyssdtEoFLQWd5vHXLQtHRCRQf7/l193cdXE+svoIgCELwEyixo4nR0ZQQHR0wbthuZ1HOBq7egueIwA1iNmzYQO3ataOGDRtSgwYN6LfffuPPt27dSm3atOHPWrRoQf/9958mVgsXLkxvv/02NW3alKpXr05//vknL4uPj6cHH3yQ6tSpw/u7++67+fOhQ4fSoUOHqFGjRtSzZ0/+7KWXXqLmzZvzZ7fffjsvV4SEhND48eP5uFWqVKEZM2bw5++++y6dP3+ej4HtICz1vPDCC/y3ffv2vPzy5cv0448/UsuWLalx48bcpt9//11b/4477qBnn32WWrduzW1NSkqi4cOHU82aNalVq1b04osv8jqKWbNm8b6aNGnCbd61axcf46233qI1a9bwMXGuQuALM3V8X7l4eWLBdbctgeLqLQiCIGQyAWLB9WWZHY9EvLsZGwPE1VsITCTJlIfUrVvX9HOITAjHo0ePUo8ePShHDsc5hH379vHfZcuW0ciRI50uT4tr165R7969af78+SwKU1JSKDIykhITE+m+++6jb7/9lrp06UL//vsv9e3bl9sDoqKiWPjCWrp06VJ67rnnqFu3bvw/tt+/f7+2fwDr7fPPP28nSEeNGkUff/wx/w/3XuwD2yty5cpFmzdvpoMHD7IQfvTRR1lIfvfddzRv3jwWk0Y+/fRTFsPr1q1jEQ7Q/oceeohFM8Q5hOupU6d4/+Dw4cO0du1aypkzJ02ePJmOHDmi9R3OSQGBP3fuXF4X2+IYDz/8MK8L4f3rr7/yS3A1+69/kyMp8ekroe1u4gpPRL/1d1x+mAVBELIbgVK/1ZeWZE9+R1Wb3DpGAEwUCIGJCNwgtt7WqlWLxS2AkC5atCjt2bOH/4c4BLDwlipVigVq+fLlKXfu3CyAAayfx44d4/9hIT1w4ABbQTt06GAnEI2sWLGCvvjiC4qJiWFhrcSw4pFHHuG/t912G4WFhbFbMo7tLidOnOB9nT17lveD4+Az7BcMGDCAxS1YtWqV3fuBAwfStGnTtEkHWGxhwVVgX7BaCxR0wkwd31cCNzNicMWCKwiCkD3RxJzFzxPGvhSI7mZEtq3r7jYicAVniMD1kPSsrLDibty4kQoVKuR0HYhQV6y1GUV/A4UFU70PDQ2lW7YMelWrVmXr7erVq2nlypX0yiuvOLgRg9OnT9OIESNoy5YtVK1aNdq9eze7/OqBiFbgGJ7GyPbv358mTJhA/fr14/cQ8PoY3fz587t0zvgRgeCF67SQMfztnpw5FlyJwRUEQRB8hE7MhYSGZl0Lrjv79sCCGyiu3kJgIjG4QQpibOGSC3dboCypsOrif1hZwfr169mCauYWrAdWUohCxNnC/Rg3pzNnzlDBggXZrVmB/2ElLVOmDK/z5Zdfutxm476MFChQwG759evXOY4XzJ49m98748477+SYXcTi4vXDDz9oy3BO2B7iHKB/EKfsSpuEwKs7lxqDGxjWYc8tuG43TxAEQQhytN9Qf3tDBVAMrqcWXH/3oRC4iMANUooUKUKLFi2iV199lWNqkTwJsabh4eG0cOFCTiSFzxE/izjdtKydAK7Nbdu2ZVdlJHVC3Cy2xwvxxvXq1WOhWL9+fbas4jPE11asWNHlNiMp1JNPPmmaZAogMVTnzp21JFOTJk1i6y3as2PHjjSP9dRTT1HlypU5SRbOA9ZlFcsLN+4PP/yQ+vTpw+eHtqvSQJ06daKEhAQ+T0kyFRxZlNXvmS/a4cm+raLf/eP4ux8FQRCEzMcTMeeTdvjSAupmhmNPRL/e1VsQjIiLchCDpEsqQ7KeZs2aseXWCAQgEkkpIHrVjeGee+7hlxHEvi5ZssTuMwhPvBSjR4/W/jfeaCIiIrT/Bw8ezC9nQJTjpUBMLV6KTz75RPv/77//ttsWVmVYnmEFhgUXsbuIMVZAlONlBC7kZn0lBG4Mri9dlD3Ztz6rs6vxVIGQjVoQBEHwA5644/oCX7ooZ4IFV9+P/nT1FgITEbhCluGuu+5iayzidJFcCxZjwbsEgjDzpcBNnRF2Z5vUdoWGhgSNJVwQBEHIfDzJGJzVsyh7IvrtRLEIXMGACFwhy7Bp0yZ/NyHLEwixo750S/JEPOvjdl39jQ0ES7ggCIKQ+WjCzN8xuO7WnfWlBdfDJFN2fwVBh8TgCoIQVLGjvrXg2h/DV+0RC64gCEI2JfWHxr/N8GWZHXfjez1NMhUAlnAhMBGB6wIqrs7fs21C5qKut1/r1AUYgSDMAi0G19PEVP7uR0FwhxkzZvC98Ndff5WOE4QMECjCzKcuyplgwQ0UV28hMBEXZRfIkSMHJzG6evUqFStWzGXBg3I0qs6sEFx9hRsnrjeuO66/kNov/p7o8aVXkqdlgtxtTyC4eguCq5w8eZK+/fZbTmwoCEIGCZTsv778PXc3i7Ja150sygHi6i0EJn4VuKjjOnDgQM60i2y2M2fO5BIuejZs2EDDhg3j/5EdF8mDPv/8c8qVKxf/6A4aNIhLyKBeqrH0zPTp02nChAksnlAn9auvvmLB4gkoUYM6qqg16yrx8fGUJ08ej46X3QjEvsJYcacMUnYgu1hw3fnB9EQUB4KrtyC4An4/kf3+iy++4FJugiBkjGxjwfVxkqlAcfUWAhO/ClzULh0yZAiLVNRqxd8tW7bYrYO6pfgMYgM/tH379mWh+sILL1DBggVp7NixFBUVRW+88YbddidOnKA333yTtm/fTqVKlaJevXrR1KlT6emnn/aoragvW716dW6Dq1/alStXcmZfIfj6ClZ6sdwGpjCTGFxByDwmTpzItcWbNm0q3S4IXiDbZFH2cTxtoEwUCIGJ3wTu5cuXaevWrbR8+XJ+D+E6YsQIOnr0KAtJRd68ebX/ExMT2dKnXISLFi3KFl1jTVQAwdyzZ08qXbo0vx86dCiNHz/eY4GrcFf0hErqcumrLEQgWHA9sZi6isTgCkIqe/fupQULFtDatWtdEsJ4KVBzfdmyZRnuTpR988Z+sgPSV8HRV1cOHOC/a1atorDChclfREdH07EjRyg2jX7wtJ+uRURQjrg4l7dNjoriv3t27aKzLm4TsX8//121YgWFFihA/ka+f4HVT34TuGfOnKEyZcpQWJi1CRCtyg1YL3ABXJFhgT127Bh1796dhg8fnu7+sZ9KlSpp7ytXrsyfZdaPMpDBLn3lbfw9pq5du84i0J9tuHjxJv9dv34DXb2a36t9FROTzH/37NlLy5ZdcWmbPXsu8d+VK1dRgQKu3VIR352c7N9+DJQxFUxkt75at24d//7WqFGD31+8eJG9ri5cuKCFDilGjhzJL0X58uWpS5cuGW4D+tsb+8kOSF8FR19t2bOHLhLRHXfcQflKlSJ/cTFfPqpatSq1T6MfPO2nn8aPp5z587u8bezlywTZjzDF+i5us/3wYbpARB3vvJPyFC1K/ka+f4HVT0GRZAridNeuXXTjxg0aMGAALVy4kPr37++VffvqRxnIYJe+8jb+HlOFCp2lW7csfm3DsWOIg99JLVu2pJYty3u1r65ejSOirVS7dh3q0qWZS9ucPLkVQRHUsWNHKlYs1eMkLSZMuEhJSbcC4sHd32MqmMhufQURqxeyeCB//vnnqXfv3n5tlyAEM4HiWhtIWZQ9yR4ZKP0oBCZ+Sw9boUIFngVOTk7W3A5hYU0rqU/+/PlZ2M6ZMyfd/WM/p06d0t5jFloSBglC8MfgelKWx5f79syt2f+u3oIgCEI2jsF1t1ZtJmRR9kQU+7sfhcDEbwK3ZMmS1KRJE5o9eza/R5wPrKdG92TE5CJ7sorBXbRoETVo0CDd/SOmd/HixexShS/xN9984zWrryBkV6zlbbJukilPSv54KopF4ArBBvJdiPVWEDKIByVxfEGwZ1HW1hWBK5jg1wKfU6ZM4VfNmjW5nA8KyQOUJIA4BatXr6bGjRtzNmX8RUZkZEcGcXFxLIrvv/9+2r9/P///2muv8TLEFYwZM4azP0I0lyhRgrM2C4LgOYFgefREhGZGHVx3ywRJ6T5BEITsR6BYcFkY+uiHKFOyKAdKPWEhIPFrDG6tWrW4zq2RadOmaf8joQVeZiDD8tmzZ53u/8knn+SXIAjeIRAsj4GXRdkzUezvfhQEQRAyn0CJHfWli7K71mFPRH+g9KMQmPjVgisIQnARCJbHQK2D6543lghcQRCEbEmAWB596aKMc/RIrPrYrVnIPojAFQQhqCyPmRGD6667sbvbBEI/CoIgCJlPoMSO+joG163zS/0hde8YInCFYC4TJAhCYBAIlsfUagLuuREnJaVQeHhouuu5u2/PY3BF4Aqu8fnnn6e7Tr58+eiJJ56QLhWEACdgYnA9cMlKTkigsFy5XNq3W7/RGcii7He3MiEgEYErCEJQWR49EZR//nmEvvxyC/311yMBEYMbCBMFQvCAhIk9e/ZMc521a9eKwBWEICBQLI/uWnBvJSbS16VL01OnT1N4gQJe3bdHWZQDZaJACEhE4AqCEFSWR09EaGTkTX4FSh3cQJgoEIIHVBFQVQacceedd2ZaewRByH4xuLeSkighMpKS4uLSF7iZkUU5QCYKhMBEYnAFQQgqYeaZxdS19TMSg+uey7RvYoiFrAnK5XljHUEQ/E/ACDN3syi7YTH1OIuyJJkSvIQIXEEQgsq11pOsxdjm1q2UgKmDi3UlbEgQBCEbEiCutXx8T+Jkb91yYeXMs+DKj6lghghcQRCCSph56kZ865avLLgSgytkLmvWrKF69epR1apVaebMmdL9ghBEBIow89SNOMUFgZspWZQDZKJACExE4AqCEFSutZ5aTF2z4Nr/9WV7/N2PQvAQFRVl9/6rr76iTZs20Z49e+ijjz7yW7sEQXCfQBFmbrsRu2HBtWRCFuWAcfUWAhIRuIIgBKWLsi8EZWbVwQ2EZF1C8IAMyvPnz9feh4eH0/bt2/mVM2dOv7ZNEAQ3CXaB68o2nsbgehITLL+lggkicAVBCCrLo6e1al1xUc5IDK57uTH8349C8LB8+XLauXMn3X///XT+/HkaP348ffvttzRp0iT+KwhC8BAwlkdPrayuWnDdOT+1bw+STLnlCi1kG6RMkCAIQWV59KWLcmbF4AbCRIEQPOTKlYvGjh3LLskDBw6kPn360A8//ODvZgmC4AHab6i/Y3DdjZN1MwbX1xbcgJkoEAISseAKghBUwsyXLsqZVQc3EGKZheAhJSWF/vzzT7p06RItXbqUkpKSqGvXrnTw4EF/N00QBHcJEGHmUxflzMiiHCCu3kJgIhZcQRCCyrXWs5hX97Iou1vT1t32BEI2aiF4eOCBB6hQoUIUFxdHCxcu5CRTvXv3pueff54aNWpEb7/9tr+bKAhCsAkzd0WoarerWZR97G6siWL5MRVMEIErCEJQCbOsUAc3ECYKhODh6NGjHIMLIGhBpUqVaNGiRTR37lw/t04QhKAsEwQLboDE4HrkbhwoEwVCQCICVxCEoHKt9TwG17d1cN1NeuXvfhSChypVqtDgwYPZgtuiRQu7ZQ899JDf2iUIggcEiDDz1EXZpzG4HghuSTIlmCECVxCEoBJmvkzq5Kl4dnebQJgoEIKHX375hZYtW8YlgTp37uzv5giCkAECJTmSp1ZWlwSlmwLXk7jkgHH1FgISSTIlCEJQudb6MouypzVtPWmPxA0JrrJy5Urq3r073X333RQSEmK6DpJPCYIQ+ASMMPNlFmVP43t9XVpIyDaIwBUEIaiEmSeJoHzpoiwxuIKvGTVqFMXExFB0dLTT12uvvSYXQhCCgQARZj6NwfVlhuZAmygQAhJxURYEIahcaz21mLpWJsj9BFaeuEwHQj8KwQPq3xYuXDjNh9HSpUtnapsEQfAM7XscpC7KrpYJ8nUW5UCJZRYCExG4giAEVQyuL12UM2LBdTers7/7UQiuOriCIGQNAiYG11Mrqy8tuJ5YlOX+KJggLsqCILg34xsgZYLctZi64qKcWTG4gdCPgiAIgh/wIGOwT5rhYabjQInB1fpPfkwFE0TgCoIQVJZHT9yIAy2LciD0oyAIgpD5BIzl0U03YrfanRkxuIHSj0JAIi7KgiAEVeyob7Moe14HV2JwBUEQBFd/M/wpzDKUtdhFC67P42kDoB+FwEUsuIIgBGUWZfcFrsVnGZo9aY+/+1EQBEHIfDRB5sffgAxZTF2MwfXEOuyOKA6EfhQCF7HgCoIQVHVwM5JFGe13Vkc0s2Nw/d2PQvAmnLp48SIlJydrn1WsWNGvbRIEgYLL8uhJzKsbdXCxf59bYwOhH4WARQSuIAhBFTuaESsrNklD3+qssZ7EBEsMruBbZs6cSc8++yzlzJmTcuSwOmBhwuby5cvS9YIQJARC7Kgn1k932s3rpPVj64Xf0UDoRyFw8auL8pEjR6hNmzZUs2ZNat68Oe3bt89hnQ0bNlCjRo34VbduXXrqqacoISFBWz59+nSqUaMGVatWjZ588klKSkriz//++2/KkyePti1e8fHxmXp+gpDVcLe0nS/ISCKo9OJwPYmn9TSrs78nCoTg47333qMtW7bQ1atX6cqVK/wScSsIQUYAWB597qLsyxq7umO4u42QffCrwIVYHTJkCB0+fJhGjRpFgwYNclinYcOG/IO+c+dOLnaPH/OvvvqKl504cYLefPNNWrduHR09epQuXbpEU6dO1batVasWb6deELyCIGSu9dTbZESEpheH66lYdX8bKRMkuE/x4sX5d00QhOAlEGJHPSrL48M6uBlxUfb7rLsQkPhN4EKobt26lQYMGMDv+/btS2fOnGGhqidv3rzsjgUSExPZCqti6ObPn089e/ak0qVL82dDhw6luXPn+uFsBCF74Im49DaeiVDXtvE0vteTbcSCK7hL79696bPPPuPfz+joaO0lCELwEAiWR4/ce91pd2ZYcMVFWQjEGFyI2TJlylBYmLUJEKhIlHH69GmqXr263bonT56kXr160bFjx6h79+40fPhw/hzrVqpUSVuvcuXK/JkC6zdp0oRCQ0Ppscce07bTM3HiRH4pIiMjadmyZV45x5s3b3ptX1kd6avg6Cfl4rt06TIKC/PP/NjOnVf478GDh2jZshiX+urYsVP8d9myFZQ3b6jTbbZujeS/58+fd7mfz5w5y3+3b99BefOm3n/SIinJmiBo6dKlaSa9yg5jKpjwd1+98cYb/HfkyJHaZxg/t1xJ+iIIQkAQEMIsAzG4riSZwrohtjwBLu07dXbZ7W3ERVkI2iRTEK67du2iGzdusMV34cKF1L9//zS3gbA9e/YsFSpUiP9269aN3bseeOABu/XwoKB/WChfvjx16dLFK+3Gg5C39pXVkb4Kln7ajJ8T6tz5bgoPdy4UfcmlS7sgWalGjZrUpUtbl/pq+XKIkgvUseOdVLhwbqfbpKQcgXSmUqVKu9zPP//8G3xSqGHDRtSlSx2XtsmRYzumC7gfQ0NzZPMxFTz4u6+QQVkQhCDHg4RKweai7HYWZbVvd/okECYKhIDFb09WFSpUoAsXLmilDjCoYX1Nq9xB/vz5WdjOmTOH32PdU6eslhll6VXbFyxYkMWtEq0PPfQQx+oKgpD9XJRd3SYzY3D12wqCO8DDAK/MslrDNRrJIJETo3Pnzg6hRIIgkE+tld7G1y7B7sbgeiS4A2CiQAhc/CZwS5YsyVbW2bNn8/sFCxawEDW6J+OHVGVGRgzuokWLqEGDBlrc7uLFi7kmIAb4N998o1l2IZ7VbHdMTAwtWbKEGjdunMlnKQhZC08EYHBlUbZf39ftkThcwR0OHDjA1QTUq379+nTw4EGfdyKSQR46dIg9qRAuNHjwYJ8fUxCyLAFgecwSWZQDoB+FwMWvvnFTpkzhF2aGJ0yYQDNmzODP8eMJ4QpWr17NwhQzx/hbqlQpzpwMqlatSmPGjKG2bduyMC5RogRnZlaCGT/+2K5Vq1Y864w4XEEQPMcTAehtPK07G1hZlN3fRhCQRwJxuNevX+cX/h82bJhPOyZ37twc4qNixfF7Cm8pQRA8IyBiRzNQdzYl0LIoi8AVAi0GF+UOUOfWyLRp0+xmjvFyBmrf4mVkxIgR/BIEwTvofwj96RKUGXVw3QsDEguukDlA1D788MPae3gsYXI4M5k0aRJbcTMrYaO/E3sFE9JXwdFXly5e5L+7d+2iMyVK+KUNyZHWhIpR6XxP9f0Usx25I4j279lDl9LrO9uPqKt9HGXb98ULF1ze5oItTGPXzp10qkgR8jfy/QusfgqKJFOCIPgfvegLNhdlVy2mGSlB5NZMuMQOCR6AigD79++nOnWsyczwPz7LLMaPH89hQ6tWrXJY5quEjf5O7BVMSF8FR18tmjyZkP+/Xr16VM9PbYi9dIkOIF9N/vxp9oO+n06GhBB8N2677TZqksY2+H3bY/v/7rvvdqlSwKGYGEINglIlS7p8XRZPn05RROytWScA7hHy/QusfhKBKwiCS+hFn39dlN1vg6suypkVgysuyoKnAvP222/nPBR4iNy7d6+WdNHXfPzxx1zBYOXKlVyfXhAEzwiI2FFfZlHWe3uhXJALk3A+r8srZDtE4AqC4IGLsv86TQlJT9yI03NRziyxKkmmBE/ArDcSTW3atEmLh0X5O18D1+O5c+eyuC1cuLDPjycI2eK31J9lgjwoy+NqDK5ecPL/rniZZERwi8AVTBCBKwhCkFlwfRfz6st9mx1HqhsIrhAbG0v58uWj6OhoypUrF1txFfgMZfF8BerIv/jii5zUsWPHjvwZ2qBEtiAI7hEIwixDdXDT2cZuMtzF/WfEgis/pIIZInAFQcjyMbi+zaIsLsqCb2nfvj1t376draf6eDaMPby/5UJWU09BLK3UmRQELxIArrW+LBPkYMF1aediwRX8LHD37NlDv/zyCxUpUoTuueceDjYXBCHrEygW3Myog+tJCSJXN9HvW8oECa4AcQsuXbrE5fD0XLlyRTpREIKIgLDgqmP7OAbX1R9GrT2eJGsUF2XBG3VwUaKgU6dO1KxZM/roo4+4ZIAgCFmfQCkTlBERGgh1cANlokAIPswyT0qGYUEIMgLBtdaHdXA9seD60mVayJ64bcEtV64ctWnThnLmzMluUx06dKDnnnvON60TBCFgCBRh5su6s5kRg2s/uS0CV0ifxMRErh0IV+SYmBht3ERFRXF8riAIwUMgCLMMuShLDK6QFQXu+fPnqW3btjRw4EB+D0uuIAhZn2COwVVt900WZXcFbmBMFAjBw/vvv09jxozheNtChQppnyO5FBJACYIQPASCa22GyvKk56KcWTG4AdCPQuDitovy7t27OQYXGRUxoxwZGUl9+/alPn36+KaFgiAEBHox5l/PKt8lmcqMkj+BYgkXgoe3336bUlJSaMiQIfxXvfD7++abb/q7eYIguIEn8abBVAc3s7IoB4IlXAhiC+7Jkydp48aN1K1bN54tPnfuHIWGhnKCKbwEQcgeBIrlMSN1cNNrtyf7djcmOFAs4ULw8fXXX/u7CYIgZJQAsDx6lNTJVRdl/XLXsy+63Z5A6EchiC24/fr1o6VLl1Lz5s3pyy+/pNq1a3MM7h133EEXLlzInFYKHnHmTBRFRt6U3hO8QvbIouz7GNxAsYQLwcfly5dp2LBh/BvcpEkT7SX4jqT4eLp+9Kh0seA1AsHymBGLaXpJpiiTLbjyQyp4JHCR1GLmzJn0ww8/cDIpiN3Tp0/TiBEj+CV4h7VrT9GcObu92p0vv7yCpkzZ6tV9CtmXQEmOlBE34kCogxsolnAh+HjiiSeocuXKFBERwTG5ZcuWpe7du/u7WQHDzchI+vfNNyk5IcFr+zz222/056OPem1/guBJBmNvk6GsxQGSRVksuEKGBC6SWly8eJFatmzJBd8xc6wsuxC6gnf4+uutNGDAIvrvP+/1aVRUAkVExHltf0L2RomxkJCsnEXZfn1ftCdQLOFC8HHmzBkaNWoU5cqVi3r06EELFy6klStX+rtZAcOVXbto49ix9J8X45IToqIoPiLCa/sTBBZxISFBa8ENlCzKgWAJF4JY4I4ePZrdk2GtxYzxkSNH+POrV6+y8BW8Q5EiufnvoUNXvdalsbGJdO1avNf2J2Rv1I9WaGiOgBC4ntXB9UUWZfttXV3f3eMIQnh4OHdC7ty5+Tc4LCyMrbmClVs2y+21gwe91iVJsbF089o16WLBa+C3K0doqH+FWUZicH1gwZUsykKmC9z77ruP1q9fT7Vq1aIVK1ZwsqnixYtTgwYN+O/vv/8uQtcLxMcn89/r170nSOPikujaNYnBFbyDEmOhoSF+FWa+zaLs+b5dfU6wj8EVgSu4Ts2aNVnYDhgwgL2qUKavadOm0oU2kuOtv583r1/3Wp8kxcXx/sRKJHgLjKWQ0FC7cjqZjUcuwZkQg+uR4JbfUcHTOrgVKlSgZ555hl/g+vXrtHnzZn5NnTqVSxdIwqmMcfOmVeB60+IaGwuBKxZcwTuo3xBYcP35e5KROFlXLbju/GBKDK6QWcyePZv/Ih8GxC1+i7t27SoXwEbyTeuErjctrrDg4oYHV+XcRYpIXwsZx2JhgevXGFxPXIJdrIPrSRZlicEV/CJwjRQpUoS6dOnCL8E7xMcnUb58Oen6dfcsrngghytygQK5nLgou13qWBCcjrVAsOAGewyuuCgL7hIbG0v58uWj6Oho7bP69evz37i4OC7hJ1gtuDnz5fPIgpsQHU25TPqRBa5NNIvAFbwBBKC/XZR9GvPqgQVXWYc9STLlT0u4ELiI+gkgC27ZsgXctrgOGfI7FSw4wXSZWHCFrBiD60m5PHeyKLsr4NEOd7YJlIkCIXho3749/y1cuDBPMBv/CqkW3Pxly7ptwb164AB9UaiQqTBWAjde4nAFb1tw/SnMPPghdTcG151ztHjQJ8rVW8IHBDNE4AZQDG6ZMgXcsuDC3XL69B1Ol0uSqeBm2bKjFBPjvXIXGQW/g8ignCNHiF9dq3xdBzcszD0BbxXFrm+jnyjIbqFD6P/ffjtIycky4+4O27dv578pKSlcus/4V0i14OYrU4aTTaF+ravs+uYb/ht57FiaFlwh+Lh26BBd2bOHAi7JVFiYX+u3+rIOrvqNc8dK7YlVW0vWld1+SInowqZNFC2VbNJEBG6AWXDdSTJ18mSk3fbGB8mEhFv8OdyfheCja9c5NHr0agoUIOBQNiwrlwlyV6wC/LjCGuvqj2ygWXBjY5Np+PA/6OBB32fjffHF5dS79zyu+y24DxJMCc65dfMmC1yQ4Iab8unV1vts5PHjDsuS46yl9kTgBiezW7Sg7xs0oEAiECyPGRG46bkEqzJIITlyuJVFmRNvuWlR9nc/am2xWCji119p3w8/+PxYuF/NadWKNrz3ns+PFcyIwPUxr7220iW3Y4jQsmXzu+WijBq3pUrlo9y5w+jUqVSxqzIoKyTRVPBy6lQUBQo8W5ojhF9ZN4sysQXXXfdn9yy4lKmu3kOHLqHFiw85Xf7TT+e4Dvc//5z0eVuUiN627bzPj5VVsyjff//99Oeff7L1NrtwcN48Or1mTbrrwWobXqAAv9xxKUad20JVqlDUiROO+xQLblDDltJAIxDKBPk4izLELeHlapIpT8RqJrp6H128mFYMHep0+YWNG+nCN9/Q1k8+8Xlbrh0+zH+v7t/v82MFMyJwffwgPmHCf/TJJ+vdsOC67qJ89Wo8FS+el6pUKUzHj193iL8FefPmZCEsBCcXLtygwLLgWl2UA8GC61kMbopPYnDdcWtW61mFtO/7ccqUbfT880udLj9+3Hp/uHLF9/cJ3Odq1y5OW7de8PmxsiKnT5+m7t2704cffkiVKlWi1157jQ7bHnayMkv696ef77zTJQtuWO7clKtIEZctuPgOxl+9SqWaNaMoEwsuBG5Y3rwsgoXgAzHZgUYgWB49KbHjTgyu1dsrxK0YXExGuGtRzixX722ffkq7pkxxuvzyrl38N0fOnD5vC+5zRWvXpss7dlBKsr33ppCKCFwfkpRk/dItXHjQZYEbGXnT5Qflq1fjqFixvFS1ahE6cSLSIf4WD9DVqhUJKCug4BrqR+fChRjT5b//fogGD16cqd2JJikLbrCVCXKnDq67llV3RXFqDG7mTRSkdQ84fTqemjUrS5cvW2MNMwLObc+eS2ne59q1q0ibNp3NlnFTGQWZlAcNGkR///03rV27ll2Wa9euTVkdPMyBuCtX0k0yFZYnD+UpWtTlTMpJN25QSlISlW7e3KkFt1jt2hR9StzqgxHlsm5m0Y+LiKC57dtnegKxQIrBJR/E4CoLrjsuyhmKwc2EiYKClSqlee6wpuapUYPiLl/2yvGQ+O5WUpLT+1yJBg14kiRi716vHC8rIgLXhyQmWr90hw5FuJxkCg+80dEJLltwixXLQxUrFqLTp6McLLgoO1SzZjE6fFjitoKNxMRbmgXXTAR98cVmTjB29Kh3fpjh4v7MM3+6GIPrbxfl1PZ4exvPLLjuieLUGNzMy0aN46xY4ZhAB/eaK1cSqWPHyqYCd9KkjXTgQNqiQs+BAxHUoME3DiETeoF7111VeSJv06Zzbp6FAJKSkmjBggU0YsQI+vXXX2nYsGFZvmPylizJfyP27Us3yVSozYLraswsrLd4EC9Rvz7FmCRtgcAt2agRXc8GlvKsCMd1Eplev0M//0zn/v2X9s2c6bXjLX3iiXQnYgLCguuBi7I2KenDGFx3XaYzqx/zlS6tJaRT9baNAjdfw4YscI2Tt2fWrqUDP/7o1vFm1KlDK4cPN12G46McWtVu3ejgTz+5td/shAhcH5KQoFxArDG2aYEHvxIl8vLDtauJpqwW3DxUunR+unQp1iEGN1++cBa4R46IwA02lIs5ss327m1/A0NM9erVJ6hVq/I0d653skP+9NNe+vLLLWla1QIlBte3WZTdczf2zIJLfkkydffdsx0SSeF9oUJhVKdOCYd7CHj++WVUp85XNHLkMpeOobJ+z5y50+l9rmjRPNS/fz2aNcvq0iW4zjPPPEPly5enadOm0cCBA+ns2bP05ZdfZvkuhHAFcRcvuuSijHq1rlpwIXBzFy3Krqyxlxy9D5Li4qhk48Z0/cgRD1sv+JNkWwz1z506UWKMvUfU4V9+obKtW9OBOXO8ciz8Ru797js6smhRwMfg+jqLsicWXLfLBGViDO6txET+u2rECNphcs9lgdugAWdwT9TVKwebxo2jPx55hGa3bEmJtvHoCnumTTN9JuP7XJ48VO+xx2j/rFniDeUEEbg+tuAiZhEPsmYPj3oggBEvW6RIHpfjcK0W3LwscC9evOHgogwLbo0aRenwYSlvEIjgxnXjhvWmaQTXD/z2W38H99JLl25wYrH776/jtVhGjCNw/ry5S7QxBtffZYLcjV91rw6uu1mU3UtMxT/KIZjgdnT1hkX+7Fn7H8eMgjh90KRJGZo8ebPdsitXYqlIkXBOVmdmwcU9CXz66UaXjqW8TzBZYuaJAk8VjN3WrcvTvn2uW4bTA14qH3+cfq6DYKdMmTK0bds2+uuvv+iBBx6g8PBwyg5A4CK2LTYdgYskU3jwg2B1VeDevHqV8hQrRnlLl6aEyEgH64yy4MIyczPS3DNB8C9G4Wq8fj0XLGDhAZdkPTfOn6e6gwbRld27KTkh4yX5VEKy9NxUNTHn31gfa8yrr+rgemDBddtt2zZRYNwGk1Ioo+OLSTa4Km+fNMlhefyVK5SrfHkKDQ93uP4qxOLi5s0Ue8G9Z7aTy5aZtgUTeZicwRhOiPJOGKIlJYVWP/ecqYU6GPGrwD1y5Ai1adOGM0M2b96c9pm4H23YsIEaNWrEr7p169JTTz1FCbob0fTp06lGjRpUrVo1evLJJ9l9y5VlmWXBhRW1ZMl8DgJUD6x0ePDGg1+RIrldznqsXJTNBW6qBVdclAOTBQsOUIEC72vuyMbrlydPGBUunNtBKMA6nydPThYsO3Z4R+CqMlNpjRV9DK6/syi7a/101eqr6uCa/eh/8MG/pnWJ3RXFytXbrB9r1PiCunVz35qwc+dFtsKbgfG1Z88wevTRBnTuXIzDdQ8PD+F7FCZOjGCSbNKkrlShQkGX2hEVlUDNm5fl+46ZFRfHw30OYRVnznhPyP/990n67jvnNcGzCq+//jqFhoZyDC5ITk6mRJtlISuDBzpkOY51x4Lrhoty7mLFWORCdOituLgPQLTkL1+e8hQvLlbcAATX6POCBen4X3+ZLsf1C8+fn3IVLOhgWUMJqGJ16rC759V03N9dARMkIL1xqsScv12UPXEJ5m3T2yaNLMrHfv/dVHx6ZMF1ss3fI0dyGR13gbBbP2aMaRsgmtu+9x49+PffLCr1zwhI9IRXjly5OJzC6AmCcdZq9Gi+hxjHoBkq9rbp88/T5g8/NG0nJ9MrVIjCCxakmDNnyBvERUTQ9s8/zzL1df0qcCFWhwwZwlkgR40axckzjDRs2JC2bNlCO3fupD179tDly5fpq6++4mUnTpygN998k9atW0dHjx6lS5cu0dSpU9NdlpkWXIgUMwGqR7kvQ7RYLbj2AnfVquMUFXXTaZIpWF/MLLiwvtSoUYytcs4shYL/UMK2XbvvaO/ey6Yu5gUKhJsKXFzbRo1Ks0iAFS6jqPGVlsBNqw4uxMyCBZmTst6ZoES/QByaWQ4zmkUZ+3z11VXsGu5MFBu3wffuyy83uzxRoCa2sC93efPNNfTQQwtMJ0vUeMFkCQSo0aKaK1cOKlUqP0+YYbLNuC3uX67mBcB6hQrlpnbtKpjW1bUXuFFemSjBef/22yG3MtAHK4i9bdWqlfZbiUnh3r17U1bHVYGbrCy4JlmUI48dY0udmcCFuIUlKG+JEnZu0GzJsFgoZ968VKRGDYoUN+WAA5ZZsLhvX9pl8owHYQIBm7NAAQdxoZaVbNKELm3fnuG2KEsaxporwswYy3rt0CH6+6WXKDPQ2mCxOEzo/v3yy3Rq1SrTbdzKomxiwd02aRLt/OYbx22ciH58vnHcOFPXXmfbnFyxgv+6m2EYcdrr33mHzq5b57AMIhX3gVyFC/PxkJxOW2azeOYID6e8pUo5WHB5nOXNy2I0wQWBqzwSqnbvTtcOOiapxfGQawAUrFjRK4J0z4wZtOrpp92uIR7I+E3gQqhu3bqVBgwYwO/79u1LZ86cYTGqJ2/evJTTlnYbM9Xx8fH8xQHz58+nnj17UunSpfmzoUOH0ty5c9NdlrkCN2e6AldZz/Dgh/g0vQUXQrVnz59o4sQNaVpw4V6of3hXSaYQ11uoUC6vJSMSvIe67lu2nHdIAKRczAsWzMVWQ/0PEESJEizIvH3kSMavLZL+gD//PEoJCfY/Crt3X6J69b6i33476NSC++OPe+jDD9dnqouysQ0bNpyhv/46SgsXHjDdxtU6uGbiWSVa+u+/M062ceyTKVO20quvrnT4XLl6GycK1qw54VIbzahevYh2TD1JSbdYtCpvAHWd9WMwZ84cfJ8A+pJiGHN6geuKKxvWw5itXLmwQ2Z3dTzc58qXL0hJSSkO5c08Yf36M7R8+TGHc8uKjB8/nrZv305FihTRJoBPZYPsvi4LXGXBLVrUITPu3y++SH8++qjDOL5ps+CqRDL6YyiXU4igIjVravUnhcAB4gFA6Oz+9lvH5bGxfP3YgmtwZca4gvBAlmxvJBFTFlyUb4k6edLBff7XPn24lqoz6ylE5daJEynmnO8T8GkldviNzhp56xbtnjqVdnzxhek2ah2XYnBNygTBUn7+v/9cjku+vHMn/Tt6NJ1fv94lCy5czVW5r2g3LZsqBGHzBx84uOmqyTOMI/x468MV1LohELglSzoIXIhjlBoz8yIwA+ug/+BdAJdmjB0zTxVQoGJFHrsZLRd0ZedOOvrrr/x/VgnF8FsFbIhZxBOF2b5g+CJUrFiR6/xVr17dbt2TJ09Sr1696NixY1wDcLgtsxjWRS1AReXKlfmz9JbpmThxIr8UkZGRtMzE590TYmJQ8ieBbt2Kon//3UlVqphbxy5fts5A/v33Srp58zpt2rSbKle2rvv33xF069Ytmjx5A7VsmcAP0opz567R0aN7KEeOE/yg/Msvf3A8Hdix4yLFxETR8uXLqWTJMPrll9V06ZL1RzwQuXnzptf6PbPczxMSblHBgp7XPNu69SK1alWEKlfOS0uX7qA6dVJvfFu3RpLFkkhbt65nIbBkyVIKD8/B/bR9+2ZKTo7n/goJSaJ//tlAMTEZs57u3XucOnQoRuvXn6B33plHd9xRXFs2efIJunAhkkaPXkP584cS7uWbN2+hxMTUB4IdO85SREQiff/9b1S6tPXG6ytOnz5DKSnJPEmmHzOzZp1hd9vPP/+bypS5ZDemoqKi2Ftq3779tGyZc1F1+PBZio+PZSGm3/fy5dYfrCVLdlOnTvY/wFFR0SxKT548pW2DH/jp03fxRNP33y+msmVT++TcOfxYWSghAZmEN1N8vHWGdt26y1SkSE46ejSCli5dqk3kucLevceobt0CnAwqf/6L2vFiY60/ehs2rKWjR2PpwoVrdue1fftFCguz0N9/r6I8eXLQb7+t4PGoJujw3HP48A7++9tvf1GePNaMpM7Ytu0sT8hcu2ahffvO2h0L9yhYmDdt+o+OHQvn6wGX7KlTG1LFinnIUyIibrCIx+v33//i70lWvU/BPbmYTYwpskMcrhK45zdsSHc9PIRicOmtEHhgO/HXX/wwjDi4Mi1bOlhwQV6DwMWDJMDDJCy4SCQjeJeYs2epQPnyHm+vJiHuX7mSFtxzjy3HQYiDwA03iAuIIh4vMKLkz6/tJyNgnBWtVYsK16hBa199lXroMtxC1J1bt44Sb9xgqzO8BYyTLTy+LBZOfgX3VJ+i4leVILV9DC8HtA/fF+MkkctuxE5icLE/fL/gwht7+TLls2VHT2vfKkvwlV27qHLnzuau0Lp+VJMYmKyKPnmSClep4nKXIKwB22FyYsfkydT8xRftJlIwVnC88AIFrNb6ChXs4nMhcHEvwaSZHghUtuCaeBGYgX1jvKLEFe49yO6OcWUsh6YsuHDJxjVr+eqrLp+rEeQsUCI5q1hw/SZw3QHidNeuXXTjxg22+C5cuJD69+/vlX2PHDmSXwpkqOzSpYtX9r1hw1wqVqwQNW1ag92Jne0XbqG5c++hrl270u+//0H584dTly7WL/LixX/Q0KHN6YcfdlGxYvWoZcvUH4LY2G10zz13cAbUwoV30223NWe3VbBv3wa6cuUsH7N581jKm7c4delyOwUqeGj0Vr9nBgMH/srXxGJ52+k6cDtG4psRI1pwnVEjO3f+S9evX6JevWrRZ59ttDv/Gzf2U6lS0dSrV1fIBmrZ8naOk0Q/1apVlUqViuf1S5Q4SXXrNqQuXVJvfp4wbdovdNdd5Sh//pNUoUIN6tKlubZs5swFNGxYTRo3bh3Fxt6icuUKU9Omzbjci7LaRURspBYtytHFi8Vo4MB2Jud6kRYvPkRvvdXB9Pjlyk2kn3/uR23bVjRdjv65/fZKHHe8YMHvlDv3DSpWrIRdn3344Q80alR7ev/9f6lBgza0e/d6bXm+fCcoZ84EqlmzFnXp0lrbBm1HreFatayCfuPGv2n37iSKi4ux2/fKlcupd+9w+uefk3TiRDEaOrSZtix/futscYUKFbRt4PJ97twmqlKlMBUsiP6so62PsmGhofsoX7681KxZM+rY0foDfODARmraFMc6Ti1adGBvDiNbtpyjjRvP0jPPpD6ggy+/vEbDhlVjK3r16o2ofXvr5J7Vc2Qr9ejRlcfjhx+etDuv3bv/o/37d/BnJUseoNtua0wdOlTmZdZQic3Ur19XevLJXdSyZXsuZZYWy5cvo2LFLNSvXzMaO3YK3X333drDpjUUYxN17dqJQytSUqyJq0JCKlKXLk3IE2ChjotLTYDVrFm7dNsYzPepAgUKcLiN6tNVq1ZR0aJFKSuDh288QBasXDndBC3KdQ8PovokUxe3bOE42nLt2tGRX3+1E7h4GC1Wty7/j4fbG7pjIHMqklvhoRYWXGwreI/rR4/S9Bo16JnISI4nNAPC4t8336TC1apRY5OyKWwdy52bryGuedylS1pJF1ga8eDPAheiRC9wbbHrEAoQH0gS5A0Lbp4SJah6r15cgkgPJlIwhjA+z6xZY+pae+3AASrdogUdnDfPVODCOrnmueeo/YQJlLtwYYflSBCEsdrx009N23fuv/+4bmrDp55KdVFWllnb/yibVKFjRxZ7h+fPJ9IZipTV18xF+cKWLVSmefM0syjj/JCtvHj9+vTXwIHU988/tXuZsmobY3YxIYXJLQhcI1p7dMdg1+GQEE7sxHWtO3Z02o+dJk/WRL66FxSvV48tp4iztdvG5mYM4KasrPVqIiw0Vy4+F3iDxBuSmfEYzZPHOsmSRkI0BUQwvg/YH+57OA+9wNVbcJW4xnXLCDd1kxmuJugLdPzmooyHwQsXLnCSDDW4YWGFFdcZ+fPnZ2E7x5bSHevq3bNg6VXbp7UsM618cFGGMLlyJdX1z5nbHjC6KEdHJ/L2EBNww9NvA/dBuCgDuKrqM+DCzTQ83PrFRSZlb7ixCo5x03jAdgaS/syZs4deemm56XLlRl63bgnOKKt3V8UyuCHnyhXKLqT6GEgVUwngempWggrurioTsytAkMGFVblE68HkjEoyhN8eYx1cuO9ijA4f3ozmzTNP1PHzz/vo7bf/po8++s9h1hqWN4zd++772bRmNI713ntrafz4dWm6KCOmEyK4ffuKDgmXcMycOUMd3H+nTt1Gd901S4s9VfG9Rm9cfH/uuKMSTZ7cjb76aotD+4ztQdZ0fKfRHnhT2LfF6p5sdPXG9YI7ML7Tzlx31649Rd9955i8CfcM3DuMbsgYG/D6wLkjNhbLjO7uyuIJ0YmwB/04A4gDxzhzJQ5XuShXqlSY71H67PE4FlD3uqlT7+X+2bzZc3c8o1tyVo/D/eCDD+iee+6h48ePU7t27eh///sfffLJJ5SVsdgSrhSqVIkfHNOyHmlJppBFWffAhgdGWFaqdOlCp5bb34/1FlwuFaR7sIU4QlZUoGJw/Zr5NouhPZybuJ/qrZrIWvvPSy/ZTT44WGjz5WMhBAGnXwYw4WG04KbYYnchWiA+VFvsjn3wYLrxtEbLG8SPmZBR5ajQVmBmrcS5th49mi5t3UpRJqEHSCa0a8oU+uPhh00z56LW6rbPPnM6EbNn+nT65+WX2Yqsd1HWtwPHwGRCnUcecSifxDGvOXM6CFyU0JrTogVd2LzZLgbXmGQK60Hk95g3j06vWmUVoAoTsQpg7a3ctStd2mGSRNDE1VuNh8JVq2quykZunD3L/QjvAT2wMOMaGQWsnXcIBG6hQnbL9ctwL8G11qOsv67G4GIdrAtY4Brc3VW9b9Dkueeo9sMPc99n5N50U+/xIgI3Y5QsWZKaNGlCs2fP1pJnwHpqdE9GTK7KfowY3EWLFlGDBg20uN3FixfTxYsX+cJ+8803mmU3rWWZnWQKZTr0sW1G8BCK9YCxTJB6YOzSpRr98ccRO9EBlJUHAgQP+Aq4z0IcAViRjKVmhIyBGENgFC96IBCQuXbTpnOmCXdUnG3VqkU4CZg+uZh1Wbh1Bs8gOlVJKYC/SogoILrvvPMHatduhss3PAgFCCCzpFYQTxCwCmOZoGPHrvMkSu/et7FQN0tUhfXhXQDrKjLe6lHnjdIxw4b94bDtnj2X+Bx///0wj3FnWZTxvUEW8gcfrEsLF9onZsC6mCgwJpnasOEsl+VZtOhAmnVwkZwJ383OnauxJVRfUscsbheWUyR/69y5KscE6/tL1RM2ThRgDOTPn5Pq1y9FW7fazx4rIEAhfh1c22wJ53D+etGnnwyB+IXA148XjCW4dQPcp9R9JTUBVSifG8agKwIX/YR1IWIxZvT3JBVzniuX9V735JNN6ZlnWmRI4OonAzGh52oN8WAFFv81a9ZwPglkVEaSKVQYyMooS1uBChX4QTat+DB9kik8pKnviXpgrNS5M12GN5hOxKosyuoY+rg9Fri5cvH/EE8QFa64GAquoQQoXHedrhMXx9elwh130L7vvzfdR5hNNELUROuEoT6G2hiDm6IsuDaLv4rl1fP7Aw/QtOrVTcWmGRA9nNnWxBUVEy4YZ0oIGa2VSKIE990yrVtTxU6dHCzAvI+rV1lgYt//vfWWw3KIR4xxJNwyEymn16xhq/Z+PHcri6lB4GI7fH9q3n8/W3yT9d+3lBQKzZnTIQb3/EarF41WPseaSdHBgovvD/aNPirbqhWdXr1aW+YsLhlJ32r160eRR49yEi49/FtqFLg3bnDWbFiJL261z0mhUALUTmDr4vE5SZ3hPqMSRQFYz/UTDKpsD0CmZKPAVbHeLsfgYqJECdyKFR2yJKtcA6BU48Z097Rp7FasH/vuoiYEMaEnAtcLTJkyhV8oEzRhwgSaMWMGfz548GAWp2D16tXUuHFjTqaBv6VKleLsyKBq1ao0ZswYatu2LQvjEiVKcGbm9JZldpKp9ASu3oKLB1QzgQvxADGlkkXhQRefwzIDkJX09OnULxxi3ZQFt1y5gnTunPwoexP1sI7kSs6ASIVlvWXLcmx5M6LEB14QPDExiQ7WXVCggL240IsWM4ELwQkghJCAxxUgilItuPaWX4w1vbus0fIIUQHxB4F8zz3Vad68vaZCpFu36tSzZy1atuyYw/5xHhMm3MWC05jk6p9/TlHHjpWpT5/baOzYtRzeYyzlg//RDrSzR49anHAqMjIpTSsrtsF6EMTIQozvTFpZlNE3+C43aFCKli49mua+IXBhjb3vvtpsnV6z5qRpmSC9TlWlve68s7Ld+sZ+RFuMlkrnFtxkvgcBtB/ol1vLBCkLbh4HC65+W3csuMAotnEs9JM+SzTKCbky+YZre/Kko7BBP0BIjx3bkSdZXLHg4robvxdwPQ/kRHzwblIvxJOjZF69evUoOjraNLdEVkJZ2uD6CbFpdP8zTTJVpAhbmVSmU3b5K1iQ4x4hlA7oEk6qOrjaw6SuP+GirCy4EMgQSpmRACi7ANdNAFdY9LUZyiJX+e676ezatY7LdcKDhaVOxGJbCEKIMqPotNjiGCHCsL1qix6IYBx7x5dfui5wCxc2TWjF46xoUU3gGoWZElQQT7f170+HdPG7egsjPAmavfSSaX1UHKP5yy/zOsZMwMi0C8tlp88/p03jx3NcqFmSKRa4RYtS/jJlqHSzZhStK+nDllkTK+uFjRvZLfvIokWcFMpZFuVEnWWywp130ok//7Tbt9GCC1ditAcuw9V79+a42PTqCavxUvHOO9lt12xcKTFntPDi8zyuWHANy/UxsblNYnDtXJTdtOCaiW19FmWQM08e6+RcOgLXYrFwjLWZFwz6ufEzz1DNfv1cjsG9uG2bXTIuTBw6K9eV7coE1aqFB9ENXCYIGZXr16/Pn0+bNo0zIAOUEdq7dy/H4GK2+vPPP6fcuguL+rZIPoUX6t6qjMvpLcsMEhIsLllw9Q+Sji7K1gdGWGe6d6+h1Xq0WmxSRYfVgpv6xYFIUJaScuUKcP1Lca1yDVf6CdesX786NGXKNjpxwvxmoNyM4TL777+OD6FK0OCHAHHXeiutKhNkJi7SE7iwFjdsWIoee6yRaW1QiDpkRDZa3pTANQoZZR1UQJjpXX2xLTJ1gwEDGtC0aTscRKo143detmhC4Or7GPvHuK9VqxjvBxZvPceOXaPatYvT6NG30/ff72KxY7SYQpSjTRDamFRo06YCLVt22WDBtXdRvnDhBgvRKVPu5eUoc+Ss5A+uDazb4NlnW9Lrr6/SSm+ZWZRRUxald/C9RrsHD16sW9+8TBAmRDAO7ryzCruYm5XQUQJUP+ZwfNwzcD8wClz9WMF5Yf9GAWwvcONMt3VH4KqxgG30ZYkgcJWnigLXHe1Jr3zTCy8soypVJnESLf3YwVhABug33ridx5crFlzEg7dvP8PumIgvhxu9nunTt9Pw4VaPAldrk/uKpk2bsvUWrypVqvCkMF74H59ldQsuHmIhUtg64kTgcqyu7UGS4zlDQrQkOfoH67r/+x/t/e47bRzpXZTxkBjjxILL9+ly5eiGCFyv/Y5CnEK84JqZlfjRBEvevFSufXvOpGu0HipBA7gUkE5YctykbZnRPRQTJ0oY5zSx4KIWKdyTO335pd14UWBfG8ePt/8MFkrlomwQMspTAGIEsFDUnQu2RVsh8iDm4B5trBerJmMqduzI8ctGy7Jyg8YkzhlbrWwFzgUZd+s99hhPAh1dtMjcggtLsy1Le60HHqBrf/2lnTvWCzVxUUaMO0R5w6FDadP77zuNwcW1wUQDqP/441zO57Rqp4k1lrMRh4Tw9x51ZOFibSfcbWWC9OWWeDzAglu3Llvm0TZXLbjqGpkKXJubsTMXZSU4veGirGJwAW9jcEdHKIYaRwpjWIYZx5csoe8bNqQ5rVtTnC7mHNcLorbJs89SqWbNXLbg/nbffXYTLXCNX/+2fV4aiN6pVarwMYxJy7K0wM3q6C24eDB1VvNRWV+A8QFVbxHBg/U332zlB2UlGBQVKhQyCNxUF2VYcPGwaqyBKTgCK1Hp0p9oFjoIjRdftH+oVuK0efOy1LZtBTvXcT1WkZqT7rijMq1YcdyhRqlabiYglPuy2TKrVS7MqcBFTOxttxXnhEzKmqsHbsKTJulmZS0Wm4tyLgdrMdydIR71kykQSnpxgPhdJWpgZcX/GKdmJa3uuacGiz/98ZU4wwPkww/XpyFDfreLHz5//gYnDqpXryQ1bFiaa54aBSWEDQSj+q688UZ7mj//gjZpoKys+nbDfRYiFJbnJ55oTDNm7NRicI2CC32AvgGYOChRIp8W55tal5cMFlzrg9XIka25LM477/ydZpmgGzes46F583J8Tfftsy81YO1H60OYvgQPrheEu7Lg6q2YepEKjLVw7S24mIiLN3WFd9dFGaBf9dvoPVUU6r6XluXVmh35MP3wQ29ONobJOv3YwaSGmfeLMzABhH7XTzri3mkUx3C1x/dn+/YL1KiRY93GzOTKlSucNfyxxx7jcJu4uDh+wQPqiSeeoKwMhIgW35aGwMVDJKw1eNDDg7X+IVRvEcFDO/ZxYulSFjF4mNS7KOMhXD1Q6gUuEIHrOj+1b8/1VPnhOSqKfuvXj+IM1w5iBNep/pNPaiVKjCiRWrJhQ35vLBejF7G5DAJCL34dYnATE7VxFWZiwYVLLKy/EJsQDkaRAavzv2+8Yfc5xlu4clGOsTcqsHVQ56JsdPVlt1SbqIFIbvbCC5yJ2S5nghJghQpRrfvv50RNevGpjoExjlI/cDHWCw1YZfHdgMhFdmIti7Lekmyz4IIGQ4ZQ4oUL/F1R6xmFOcCkEFz4kbzq6G+/Wb+jyoKrP0edwIW3RLMXX6StH3+cum+DwIXLNrwuIGJL1KtHbceMoeVPPaVZZc22QXwxrjmOjYkAvRu0di2cuSjrYnCNIk/vKZDL6KKsE5x5zJJMuemirLIo87EKFXLYxmjBBVwazSCsjRxesIAajxjB/yORmcO9s0gRLbwjPeBSD28XfdZ5jAPjtrAqI5s12vxDo0ZeqTftKiJwfZ5kKowtDHigclanUT38AzysORO4HTpUYuHy4Yf/OVhw03JRhuUJD87ippw+ELQQT337/swCBhbaiRM30qJF9hZPJRy6dq1u565qZqFFllyIvjlzdjssVwIC18iZi7LRbdiYZMrRgnuVxwlcN/WxohCi1at/zmIBsbIK7BvjBRMxxmMpy5XeRRlCUSVlsu4XVjvrzRZCb/z4TjR27Do7i7SaxMFrzJg7DPHkqZM1H33UmRMT6eN4keW4TJn8/D9i0VUb9OIQ+4d4g8gFd99djSpUyE2ff77JLgZXvw0suGq/Awc2Ysvx4sWH+XtjTEal/x5CiA8e3JiTTcFSjecLY3wvzgHiGaBNX3/dnSZP3sI1hVUMrpkFF+MFx0cW5NWr7X981XnimustuOg/jFm0z+gWrI/vB2YuzLly5TCNwbV6loQ5FbgQitOmbTeN5QYY8xhz+rYYBS72j4k4Mwsp+mbVquP0wAO/8HqPPNKAxwkmSBQQtGpsGu+dzlBjS303cD0w2WEUx0gMiP3hvok4bf2Y9xfI4gzPpBw5cvAL4TwoKZWV0QsRPOw6E7j80BoSwg+fRtc+5aIMYL3Cg/W/r7+uZc5VFlwVPwl3TqOLskpCJRbc9MGDNhJHHZo3j5Y+/jgd+/13OrJgAZczMbNsVenaVSuhY0SJVIicBk89RVtsgki/XFnWcO2SDC7KevGrt+6yi7JtO4wvowX32sGDHNOKMYFJDn1t0+VDhtAy28SSvnQUrGKYhIE4gejS71NZV5UwyREeThZd7VIWNbpM0nA1hjup3kKmBBi48/PP6ew//2jHgLDHMdnCe+edVKNvXzqpS6iGDOQoOwMq2zLBQ6xyXxhK+SgLLmJZS/Trx1Y53Cc1C65ufYh09A32jUy/5W+/nRNZQWDimtmJeN1Ek2bFXb6crh44YJrAChmx85Yqpb1HQiXsU40Bs7hd/TVHP5gJXJwjrrmZBRf9Z3QLxv4x2eXURVmfZKp4cV6mr0ublosy+gd1fjHZZozl5mNhos4wuaKP+XXFgnv96FH6Z9QoOvTLL1RnwAAq0aAB9612PJsoxXmZuUSbgQkgoP9eQOAa3ZuVpRhtwySLMWGWLxGBmwlJpiBG8GDnzE0ZD5V4uEy1sNzUHnwhEvQP1l9+2Y1LzyxdeszOggsLkV7AWi24qTWGrXG46acnz+7AlXjgwIa0YMED9OSTv9Ovvx7k9++++4/dTKqysKLED4TItm2OSYGwjoqvfeiheg5xlUrQAFgH9YJQbwkzJn4yuiir7LQKjINKlQpxkiN9FluMG6wPcYaHezUeYW2EyMDYMx4L4gnnqcaSc4GbauWAKz1cYfWuxno3Z4x1vaBRLspKIGPiRi82EMMKt2PVF2o9vVFdJZhSYMz37FmaFiywJo/C9wnfQXwv7IWzdb+Ilx09uj3t33+Fxar+/CBc0efq2EoQQ4g+/vhi3jf+12+jYnAVdeuWpJEjW9FDDy1g0YT2GS3K1iRT1mMgDtcYq6yuByYv9BMXavIA+0zLRRngOrkTg5s6AeMocH///RC99toq7V6F88d5q2tl5qJsFLhoM8aFfjzge4bvHaym/fsvoOrVi9K6dY/x98g4pq0WXOt1x2SFPqmVMw4ftj4EqP2gPzChZBTZ+H5gGf5irOmFtb9AosVDukQrCO9JsMWoZmUXZVcsuPxwWrSoZpXSP4Sy5Uj3YI0HZTwkrhk5kkWOelhkN+Ty5TURa2bBlRjc9IGVFWLnkY0b2UUUghCZXpE4SZ+VWImRItWrc1mXbSblbfQCFvtAiR3jcs1Ka3BR1lvCjDG4RhdlYxZlXOeClSrxmIDIUoIAiYv2z5nDQgGliSL2pYY2wJoFK6myUuqPp9yL7Sy4BoGrL5WE/+FOf2zJEu0zvTu9ErpK1HACqrAwds9Vk0F6axpbcMtayxWq9mklcnQ/phAouWwCFxTr0YPPGeKFBW7u3Py9UEDg4HMlRO+aPJmu7tvH67DA1Z2j3oKrrLgtXnmFfrnrLj4PTCbp10d/qpJPqs/unjKFNo4bx9ZpJbj1IlolmVICF2PRLB666G232Ykz1ZdaFuWoKE04I14Z6F2U9cnu9BZV5Q2i+h7CFeek6uAaXZQRB4zz0buj4/6jXSsTF2UzCy7X3zUI3KsHD9Li+++nmXXrspi/7/ffuURaPt14VueNc8J4wESFMamVGdcPH9ayXBstuHYTJrb7NSy5mLxIr9SbNxGBmwkuyrhB4qH+yhXzQuJ4gFLWWDyg4l6Dh0m4h0K86B+s4XYKCxkeAPUWXDwY4+FdPWRbY3BT63tZ43D9n2gKosIs4ZKvMJZFSYsJE/6lH3/cy9YzWGaXLRtAvXrdxqVhkLAJ1jfjw3+NGsXotdfasdAxWnj0LsiwphofoPXLjRZcq9tvbo9icCF+cDxYEHFMVcpo5coT9Oqr7ejbb3tyzLZygcU1gRgzy9hsdR9OnUgBEGZJSUYXZXtxif3prYF6LwWIMb07qH5ZaiZx63JcO6ul1fqjqGLVzVyUjXVjixcP1wQb1sVkgr6kEvar3IiBEmZKrKpxo66LclFW37dff+1PS5Yc5rGB+F799deHHSjGjOnInhYQbXBPNk4U6K32/fvX44kTY9kk7BcCV192TD95YGah1QtctFvFAqdmUbb+DOCa6UuN6ceZ1Rqb4FA6Cfcu/ThCn+Feo7ZJz0XZmHcACcqaN/+W3dSHDGlKZ868QB9+2JmqVLE+cBm9EvT3TpTb+u+/M9Sp0w885t9/fx17ZCCWFmIc7cMEhupTJVhhnQVmFlyMKzWGMF78DZIxInFip06d+IX/UTrI1xw5coTatGnDcb/NmzfnfBiZBQsRncDVx47pwYOUergEejdDthzpHqzDcuWiHr/8wjFpSjAo8HCsLIlGgVsgQGJw8T2DNSaz8mog2Q9cEl0B5UqWDR5M5du354f0/mvXUrUePajlG2/wX87gq/arc/vsOmMGJz+K0FlENddQm4DNW7IkixW9tUu/3BiDqxeNZjG4mgXXxEUZ4gfHAxAE6kH+1KpVVLV7d+o2axYLKIg5Oytp6dIsujBpom+LMYsyLLh2VjuDwOXzLV3aLmGRyvLL24eGWoWYbYwr92VVV5YtcTqBq7fgqjbwD5HOgssu+zExPFGkyGFL2ob9Yz30tRJ8ar8QhfhOcV/ZhBlEGAtc/Tkavoeg7Xvvce1ZxDnDgqsXuHqLtaJs69bU4aOP6Nc+fVhQsdVXt41+wqNw9epUskkTLgmkB/uFwDXWPlaTEHARx7mq+4Ca/NAmRPLn1xLYqeWqT3GvwlhTmdrVuMIYY3djg1hF6SSgn7jBeSFcwpmLsr4OrpkFFxbb+ffcQ7OaNuXkfIOPHaOeP//M4xVgXOvFvf7eiZh4vEd8LbwwTixbxm7nqEWNBGJX9u7lrNkqo7VeKKPsEvebbtyr+7Wy+IrAzWIuygACF26hiCEzonfRhNCBpQIPqerBWlnyFM8915JefLE1l1VRqOOoB3i9izIIFAvuc88tpQ4dZrq0LsqrGJMVuQoyoo4Z8zd17jxLs+KlB2IwJ0zopLnBIlHRvHn9WBih/2CdMnv4f+WVttzvn366wakLsjF5mHG5mQUXYgVA9OhjUvWZcc0ELixTEAJwjQdKEJw6FcklowDiWZWbsl5AGsU0zlntB5ZN9TctC646XyUM0DcQN2qMQ8Dq+0LF4Oq3VWID+8a2ypVYnzDJ6KKsYjEVBQqEaSIbz4EQd3prt96Cq9+3+t4oN2V1XZR1VQFBiARiaht9n+D7p59gUm2eNasP9ynOD1Zo/TZ6Cy5i6pFxWl/PV9W+Nlpw9VmuzWJw1VgBGMv68aK34GKyBmNEfef04wxjwFjLG66+uFcpzwTEsaJPVGZ3THroXZTTEri4ThCfmChCorK9e4fTiBEtHNbHpI3ekorJBSV+MaYPHIjgiQHEzqJ2Mu43H364ngYMWESPPLKQHnvsN243rMKqD1XuAmMMLiYklQVXjRd/g+SLBw4coOeff55f+L9Hjx4+Py4qECDhIyzGo0aNokGDBpE/LbhI7mOapVYnVo0uynoLLihRvz51nzOHxYoefU1UBxflABG4eABGCRv10JgWsL7hgdcTIKBXDBtG6995h1a4WIUCcX4QIbfbJl4gllD3tHidOiw49DF7ykVZlTuBC/LKoUPtRI5KMgWU66zeMqlfbmbBVS7rLMx0Il3v+m6WZIrdY20ClwWB7UEelijEmwIIM2XBhejDeFMiUu+OigkCuMXCqqpZcE1clI0CN48hrlLF2CpYeCoLrnEZBI/egqsXuLb+UuJTCVz1fdFbcLkdKjOwxcITQHprt36/3Je284MIgwu03bU0eFIACHKUJFJ9ol+fv3+6CSZF4+HDqWjNmtYkUwZRzDG4Ngsu9t3kmWcc6vmiTyFw0ee4Nty2uDgW5eg3FuEhIVr/sUgNCdHawmNJN16MghNZrJVwVX2F6w6xaZyggyUU7two4aSINghcvQUX54qXmcDFeWEZ7g15S5akh9ato85ffUUFyqdqBQBru97yGnn8uDamcX1RexcZsZGFeu+MGSxuN44dy/HPq599ln5s3Zrd4/F9VkIZYwhZuoF+3KlJBHUPMqtl7SscnzYEr4B42NWrx9CuXXnp55/z8vuhQxP5Qfvee9dz6SLU+O3VqxeXyVi3Lhd9/71yk4qgyMghtv+PUYsWjR32X61aNfr4Y2sppcmTJ9PkyV/hkYyaN/+JH5xxvKio2+m551rxOgcPzqY//thKc+emuk2C4cOH09NPP609PCHjtJGJEydSF1vMBspTmPHbb7/ZnZMZmPW3irajVKdOHS2bLLhx4waXgvr669ksJidOnEQvvjiOXRL1FsS7776bPrW5Mb3wwgu0XBdjoj+nkJAW9M032ygiYjoNGfIevfpqXjvBYTwnCA08+H7zTXGaOjXE4ZxOnRpPTzzxqSbkIKCfeWYi9ehxmN13n366CL3wQh+aNq2YVgbl+PGrNGbMb9S58wp+iD92bBnVrTtRa8PRo1dp6NBJ1Lt3dypQ4Hae0FDnhAf0Eyfy0fvvh/ODeM2aaGtX3m79+g9p69Yo+vrr3CzsIH7r1n2Lz+muuzrzA/kjj9zFQjQ0NIJuv/1HbuOFC1fIYukE+URlyybS6NH9aPJkWFrjWfSgbfACiI4eqMX7Pf30UBYmdetOolu3YPmy0O7d5Sk5eZo29rZtG0uvvpqfxo5NfRBMSalKV6++xP8/88zzRPQLdehgreuHvo6KukpffJGfnnlmBB9/3boJ9Ouvz2oWtZ07w+jTT/PSc8+9xcITwhvXyWpFjKb9+3HrCqG6dT/h6wRRlzNnpN34jIqKodjYm1SnzhxKSRnMEwVHj26munVf5eX4jkBQLlqUh79Pw4dbr82JExhTv1KDBj/zBDf6JEeO6/Tii5EOY89q/Uug5ctzseCePDmCv08QuBMmjKDRo83qJDehlJTqPE5efLE3vftuLrvxgPPFOaE+8uHDR6huXev30yqGr9K3386yia5H+PP//ltDu3d/yH2B64iJrLp1P+dzatPmFZ78wnX66quveNm//4bSt99av1MREWWoQwdrLNnHH6Ou4lyqW3cuf1dwXTA5MXnydSpZEvVqz9vdI/B9yZ07lN55ZxrVqvUtRUaWY2GuroEaVxs3vs7vH3/8AxbMxnsEBOYrr+Tk8f/kk9Po+edb8dgbaYjXA/HxBahMmTHa2FuxYizt2ZOfvv463OZlhx/TarRsWRcW6Hv2/IA83Ly+3rOxTp3edOlSbW7fq68+QTlyHKJ9+zCevtDWuXChJSUlVbIJ4Ml08eK9VNE6n+FXUPIuM0StAsmtUOVA3WtRY37EiBF8HY11642gjJECVQzy5MlD8fHwKkmdZMmVKxe/YmNj6ZbO1RDVEnJYLHRx1SrKHRbG+7IUKkQRhw7RvpkzKVflylTt3nu19W9cuUK5ihbVjpmcNy9dvWSNeY9H/VrbPhQFCxakyt27U8mOHbXPEdeMB9H4mBj+LCoykhJCQ7lt+fLlo5wlStCVs2e19T05p/BweFHcoBSdG19euEkb2gdwTLQpxijmEeOHkf3ff1Q5Xz7NJZPPOzmZrp0/zw/+4fny0fTmzQl3mGdRckVX0iMU7oj58rGLu97NXX9O10+fpk3ffMOxqHTzJtcQzlutml3bjed0aMUKajRsGIXZLHX6c7qVLx/dOHqUrwnOKfLaNbqVMyevU6BAAWr97rs0vUkT2vj111Rv4EBNXITkyZN6XfPkoYgzZygfrLmJiRR5/TpbTLE8GTVikSTMdk7XLl3i9XEuED2xtusKYqOjqaBNsODsb8TH8/WG2MA5sQW3enXruCtShK6cOcN9i4Q5pe66iz/HGDy7Zw9fYwj3hBw5KCkcYT7RfK4QJlh2dvduSs6Vi1Ly56ebKilUaCgfU7UnEuMX1rrERO06oe1RNgHB53P5MiXnRvK+aL5OEDVRFy/ye7QvBVbqhAQeeyl58vD6av9RNrdXXKfE5GTCEWITEuiWTZxgvWs4R5TiSkpiCzPGHsZwSqFCvP8btrhlWPPVfi8dP045SpTQxh6S33Hrk5MpCUmmkpO1c+Lvk22f+rGH/sc2SfjBtVgoLjaWkm/domhcy5AQ7Zz03yfcCyBrMc5xHlo/Xr9O+WwCHp/lKFWKIi5c4P/V9+n6lStUuUIFPualEyeobK1aFHvlCr9PDA2lZIxl9GVkJCWXK2ft91wwQsTw9hC46h7BfXv9OiWHhfH3jNtapQpf8zJ3302x166xJRt9ztczMpKuR0RQ3gIF+JzO799PhVu0oHP79vH+wmyiMMR2L7sZEsLb4P6Ca37N1s44uD7rzgn7RjvXf/EFRUdF0cNTp/IEg/GegvteePHidNXWJwBtQJiAuk55a9WiyydP0oX9++nanj10af9+7uuTmzdbY6vxu/3PP1Stf386u2EDn0/s5cuUkJhIefLnp6vnznH7wdXz53nbqGPH+DpjHOWzjR9373u4R+Aeg3HgCiJwfQSSo8ACpDyIIDCUa+Ds2bvp/vsLkpqYQhweXC4VuLCbN59jd2S9e2Fa2DxNOJOrqh+u3yce5JOT7TPf+QN1PpGRCWzJgiVFWQbxo1e79mSOf0XNX3DtmjVeEVYhd9yNkUnYanG9xeInOjqRa26qflJAlKi6onj4VoLbSFgYSuPoEiukWBMFKW67rQRPLMA1UglclbkXQKTDYlu8eOo+VbKhVBfl1IcMfInV9cM6+thRtEO5IeGvPnuvytaN9gJlJcyR4xafe/Hi+TRrHYQrXliu2oljYZwq66jeEmk9prWGq32Mqn1fAIgqZcG9eTPJbrn6X3kbwHoHC6gqV6d3P8Y1xySHOt8cWlCFtS0KCH2jFVn1H/pLuShfvZraj/rzVm3Wt48TWHD/Op6f1grdddC3B9crXz7zbRRmtXz1x4HVdPfu1AdS63V0jN2Njr5pd/3sl6XGcluX22duxrULD089B+t1sIY3qHq9etdgTNTDjRnboT2wmiuLMIQgXN8P2BwmjG7k6BMzCy7WwzJM1Lz+evs0+wztUrGz2LfeUwVNxTUMCclJCxfaJ4XTg/sNJpzguVCt2ucUFxfl4AmBy6Leq/q4WD8QBG5mc+bMGSpTpgw/iACMiYoVK3L9Xb3AxQQbXnphXEhnkcKEIiaGMEmECQzFI488Qo8++ii9/vrrtF2XYfO5556jTk2b0rh//yXYGobY9jUYmZDhYTNoEN3UicpxPXpQwbg4u2OCedWq0aFz5+jx/v21z/BgtXDhQhbuo0eP1j7Heb1Rvjwt/flnmm6b+AWTbr+dxo8fTzOnTKGfLl2iF23H8OSc7rnnHraG6+sXjx07lss93XfffSwQFMiYjQkNTCro+WHMGILsaf7YY3bn9OOPP7LLuv6cEBmJqcahbdvSjK2p2e2bNGnC5zRr1iyao7NwmZ7T4cPUGffsRo1ods2atMsWf6c/pycHDaIzyjo7ZAiNvXzZ9JxG16pFlkWL7M9pyhRasGABZwt/BhNozz7LL5zT5+3a0cHkZLpLd10nd+9O077/nv766y+apNxPv/ySGtaoQY/HxXFmcbtzunKFhvXrRz9dv04jdfu5t1IlKrRsGb32yiuEgnpv2iyXOKeahw7RM//+S2dfeSX1OhUoQAX37aNHV6+m+Bdf1D4PefFFKl6iBI1OSaHROpfagitX0s2jR2no0KH8/rUiRShPeDi9S0Qrdu+miRs2wNWFl5UtUIDG3X03vfLKKzRp0iRtH7XCw6nCsmXW67RzJ9Gjj2rXqXdKCj07diz9/dBD2vprnniCx96oceNo19Gj9KRt//eHh1Opo0fpucGDU8feiRP8fVqzejU9OHiwdp1eK1TIcew9/jj/mdS2LZ0zfM9yh4ZS6WXLHL5PZXbsoInbt9M3GzemnlOvXk7HXrv//iNMffbp04eWr1ihff5IcrLp96kfnq2uXqW3N22i/rr2vNSxIyUvW2Y39l7UndMQ7MN2Pm/Wrs1j7+yOHfQm3quEcyEhVH3FCjqwZIl2TugX3CM+GTKElp88SY/rjlm3eHEa17+/dezNn2/98L336K62beme8HA+J/V9erNECbq/UydquXYtTc+Viw7Y3J3RxqcHDaIqYWHUslMnu3uEZdw4at66Ne8HT1ZvVq7Mn2vXadgw64r//msdT3/8wd8nNfb0970Nf/1FY06douds7S+TNy99+MgjDmOv9vz59PjNm4Q0XdrVSEmhFhhPSUn02Y4d9PfRozTCNsHRtUABuqdAAbrvscdol82Cra5TgW3bCNPHl3BdbdfW3fueukeocypXrhyliUWwo1y5cl7pkZSUFEvVqh9afv31AL+fM2e3hegdftWpM9ny1VebtXUrVvzUsm7dKe19kyZTeL0HH/yFl7lK3rzjLAcOXOH/27f/zjJ79i5t2YIF+y1Nm07h/zdvPmv59NMNlkuXbthtj+WjRq2w+JJHH13I51ajxuf896mnfufPly5dajly5KrWR3i1bTvd8vHH/1latZrG70NDx1g2bTrrsE/0MfZ7/Pg1fn/lSqylY8eZdvsKC3vXUqTIBMtrr620fPbZBsvYsf9YBgxYaMmff7ylUqVPLW++udpy8WKM03Y/9tivlrffXqO9L1Tofcvu3Rft1mnU6BvteoPw8Pcshw9H8P8nTly35MgxxnLrVoq2PHfusZaDB63XC/0+bNgSbVnhwhMsu3ZZ9//55xstPXvO1fqpceNvLL/9dlAbV+3afadtt2fPJUuBAuO19x06zLDMnLnDsnz5Ue5zBcYA+gVt7NZtjuXdd//mz69di+PPo6Nv8vs2baZr46h8+Ym8rFevuZYvvtik7QvHw3H1vPfeP3xNwOrVxy3Vqk2y+27kzPkuX2/QsOHXlsWLrecDXn99pTYufv55r6VFi2+1ZTgPtAHju3nzqdrnw4cvcRi76KuCBa3XqXTpjy2DB/9m6dp1tra8XLlPLP/+e8qhT4YO/Z3/Xr8erx2zVq0vLGbgmmHdJ574zdK58w/a55Urf2b555+TptuoMXnXXT9Ypk/fbjpewPff77TcccdM7T36qEGDr/k7nifPWO3zZ5/90zJy5FL+/+jRq9y3iqef/sPyyivLtfdY77nn/tLe47p88ME87X2/fj9bPvzwX+06oC/A2rUntXsRvktof8uW33LfVK/+udaO559P3fcvv+yzu3YYM2oc63nppWXcDrWftJg2bRv3m/pOoS1JSbcc9of2FS36Af/F905/L8D2U6ZstZQt+4n22cSJ6/lvYmIy7+PcuWh+j+9osWIf8NhHX2BMBdLvTGawdetWS82aNe0+a968uWXVqlXpnmNUVJT2iouL48/xV//5zZvWe82NGzfsPk9ISODPp/Tvb/nlwQf5syvnzlkmEFk+IrJMvu02y/d33qmtv3zECMvqkSO19ytef93yHpHlp44dLZ8XLWo5snat3f5BUlKS3WcxMTGWJQ8/bFn33nv8fs24cZa5vXpx20BsTAzv8+z+/ZaLJ05Y1k2YYDm/ebPdOa396CPLZyVKWFJu3XJ6TjiO/nO0A+g/wys5OZnvl8bPD86fb/mAyPJF1arcnk/LlbNcvXyZxyf2hb75um5dXjaWyLL3++8tC/r1s4wLC7OMzZHD8tfIkdo5of+xz1O7dnE/75lnvR9EX79uWTl6NO8Dr/eJLJ+EhVk+KlTIMuvuuy0r3njDsn7yZMtfw4dbvi5XzjIhd27LgkcftRxatcrpOW2fO9fyXYMG2jnNf+ghvk74H5/hfJe/+qpl/sMPa9ssfuABy3/vv6+9/7pePcsuWxvRn/P69rWseucdXnZk9WrLV2XKaOeE/Sx/7TXr9Tl92jKeyHL92jVe9s2DD1p++9//eD/XL1/mc8Q1Vdfp22rVLPuXLOH3f7//vmVO9+6WxMREy6d581qOb9qktQfb4Vos6tPHMqVhQ+3z6W3aWPZ8/z2f06p33+VxhM+3zZrF43flyJGWGR06aOvP79/fsv699/jY6rNjGzZYPsyfX7tOHxQowJ+p79Nv999vWTt+PL9fhn4bMED7Ph395x/LxyVK8LJrV67w9Ys5f14be2j3R8WK8fcp5tw5/mz3okWWL6tXtxt7CxYssPzSvz9fp0WPP27564kn+Hwx3rDer08+aVnyzDN23yc1Zr7v0MGyZ8YM7Zzez5PHcmLLFoext3vhQl7/t4EDuW+iIiL489+HDbP8Pny46T0C54pz+uN//7PMuece7fOf+vTh8aLG3uUzZ3jfl0+f5nNKTkqyjAsN5fGOc8WxcZ7HV6ywTKpcWdvPV7VrW4798Qef055ff7V8Ua2ado84s3atZXLFitq6S0aMsCwZNoy/f2jrpqlTLd+2aGG9hmvXWr4qXVq7R3xYpAjfi9a++y6fK743p3bu5L45vnGj5ciyZZYplStr1+laRAS3//rp03xOuPfgfeT163bX6cCyZZZPSpa0vJ87N+8nxfZ9Mt47+Lt98SLv48r589bvQr16liO//mo39rC/cUSWz/Lnt3wQGmoZGxKiXVd8j9D28/v28ftPSpXiv7jHzGre3LJ91ixtP1ObNLF8lDu35ctixSyflS3LbcSY8uS+Zzyn9H5HxYLrIzDL/dVXDahLl9v4fePGpe1qreqzleoTpQBl0Zw3bx/HlbkKrBfKKqbPopyaZCqGrR4PPDCfXYXHjVtHixf3p9atK/Dn27Zd4Fe3bjXo9tsreSExyVVav/4MNWhQiho3LqNZ2mCZRm1J1DydOXMnDR/enObOPUc9elhjDhSoM/vii234hQRZo0ev4ZjEFi3K0X//neYyJajpCssKLExIvIV9NWz4jZYsB1bbTz65mxYvPkTr1p3m9WERRKwgYmxXrnyUa6uaWZb0WDPM2pdQMVrX9QlwYN2CdUllSYbFCH0MKy1iE/E/rKepWZTDtRhpZVVWFkljYiB9+Raj5QnHV+Vp9LHXaEulStZYJFC7dgnN6vXnn0eoX7/atnbksqv7CjdU9CFQllxrkimrJRTWQqxrtJ7qM/LqY0Stxwyxi0k2LodV8OjR66YJqJzF4KKGrD6eVqGOoyy4+r7Sl5gBKt5UxZCqc9TXwDWiroO1TFBqe4wx8GbAcqks4TiWfrwAY2I6ZSGFZRfutyoLN/qoTp0S2lhBAjB1fLh0q/hlgPX1saQYg+p+A6pWLcxxrQAeB6pP1NiGPsdYRekrxKvDYoy4XexnyZIj9N57HbV9WbMopx+DC7dmuOQj03h64Bqr7zaSRSFbuN4KDypXto7zl19uw1me8T1HX8ErpH79klSzZlHO9D1s2B9aqaa77qqqjQmc6969lzk7M/oLbujDh9flTNhEmVuo3hl79uyhX375hYoUKcLWs9tus/7O+IIKFSrQhQsX2P0QVlyMAVgWYMlID7jDGYH7K15G4JZmRqVBg7RwEipYkIrXrMlxa4mnT1NIvnzaMRKvXaOC9epp74uWKUO5dclbipct69AenI/DZ3nyUEhSEn+eJySECuTPr7Utb/78VKx0acoRHU37pkyhk0uX0tZ336U277xDzV96ie9t19avp6QrV+i/d97hup3KC0JPfp1LcXr9hbi6S2vX8s26eq9evL+T169TyXr1uJRNxcaNORnW6QULKGLXLoqpWpWthsgsi/NHPB2y8eKFOrQom7Lu1Vcp3yefcPzmrq+/5jhSnAviVfdeuED1HniA1r/8Mu2ZNo33AbogCVBYGK15/nmK2r6donft4vhC1Fzt+NlnVOGOOyiv3kXJ5JxKos7wtWu2hIYFKWdyMhUqWlRbB27TJSpWpOjdu7XPEOuYp2BB7X0R1EW1xTXCNTpnUhIVLlaMlyfaklApF/Gw+HgqWqoUj7eQ/PkJd7O8YWEcY5nbYuHrCQohsRDGZmiodhy4KJeoXJnfl65Wjc4sXEhJcFmNi6Nydeuy+zdQ/XN00SKq1rOntn3hokU5ERHOKen0ad4Gy9BWbjuSN1ks2vo54uKsZarCUSrO+juQA1mcb9zgWNQwuIbGxFDJihUpv20bTgYVE8P7CL1xg8cmzpvHf9mylCMqit06ET8cZoulVTHlaHeu5GR2G4WLMvbB7SlUyO6aYeyHI5NxXBz3Hb4fuOPi/9wFC1JYbCwVt8Vvqu+T6pO8uXNznC/OJyw0lK9HsTJltO+Tuk5Fihe39r/tvpAbfYBrBK8imyuvaosCFmScE9zTsVS1OSfcZG3/4zNLgQKUF0m/kDAObuHnz1P4rVtU7rbbqCgSgsEFPiSEEiMjqWiJEtp+0A+I58U5hWOcFimiLYvNl48scXHa+1wWCyc4w68d2lq+Xj3advo0L4+8dcsaf2t7FStVio8Ze+IElWzcmFq+/jpVbNiQx1jKlSt0avlyKt28ud09In+ePHTL5paLc8kXHk6FbLHlijK1alHK5cvcJ5WaNeNzwvma3VPylyjB+8CYyV+yJN08cYIKVatmN/ZCGzYk/Fe9Z0+uXYuYXsT8I8YXMbyIyS5Tpw5VadWKLm7ezNevfIsWdBpu3La+Qf8lnjlDJWrW5JJXuH8hvjskb167dpm10dnnzs7JDBG4mQREQtu2FTjLJx6ylViCCybe60WJyuqJZDLPPgtnANfAw6h6gDdLMoXkLAsW7GeRdejQCJo6dRsnYfr00y7Utm1FfviEGOze/UfaufMpqlbNPnudq+AB6Omn/6Tp03dQw4alaNeuSxQV9SrvH2Lj6aeb08svr6Bhw5rxunffPYvdDhcvvmLXX0iyo2//3XdXpU8/tSbpevXVVVzSp1mzstzmLVvO80Mp3L/VAzuENB5S7723JtdFhaA4cSKSM9kqV09XgYuxyqIMMQIRkZbAVddBnyUZx7O60ubWBKtKKqTPXqxchFVmYjxk65NM6ZNTGQUurjHaoahcuRALECTQqV49NXEEjrt582A+D0xCPPRQff4cbcQ+lWsrJl8QCwrUhIk+Y7BKhKbPoqxPHGTM8muWKdm4HNdMiV/r5E/qMnXecL22F7ipCZrMhDbWtSaZUhNA1oRN+sRUSqyq7406R/SFPpO5Hn1iKr3btjGLuRl6V2NcU6A/BwhZfWkx3BdQDgxtxljGWKtSJdwuY3PqBEUC95t1oiS3XXvVsYx1cAHuQxCb6rzxXQEYUxCoyJyMexaSZWFf+C5A2L/88nI+3wcfTI2BNmZediZwH3+8MSeDUhMpaVGjRlF2GUZfo55zx45WNy09//tfQ560wv0WwhUiG9cHZZcwYQjBj/vJfffV5v//+ecUi1e0DeIf7fzf/xbRm2/ezonn0O+DBjWi5s3L2bmh+pOHH36YvvzySw5n+eijj6hBgwbsVukLSpYsyS6Fs2fP5uRScBMrX758uvG3vqJGnz609ZNPWGjoE/CgrEvFTsgxYAWZULn9jRtz0heUfHEFfU1UY5IplWgKD3wH586le+fOZVG4sHt3Fpt3fPIJ10VtP348bf/iC8663NDF5ExmIHvpkv79+eETya2QabhG796cUAgJjlCmBglkSrdoQaufeYZF2dyFC7WkO0hChFqjCgjQqt260R8PPcT9dfCnn7gGJ84RdVWRQfXX3r1ZBOyfNYu3KdOqFV3YuJFq3X8/x/rW7NfPmtCreHH+/VZJhVwBmVr110yfRVlroyHDqz4rrlm9Ty49YxMDSGAEUQnBhlhBxCqrxE1qH9gfRFOKrg4u1uXkYrbrjoRR2K9KMoVJAiSXwsQKsiQrcQsGI3lOSAhnAa6n62uuu6tiNBHn2cqaD0UlBzImVDJLMmVXCkhlR9ZnCi9SREvog35FfVNt2yJFePxiLGNiAzHIxrGM5fokU/oETcbrhnNHkiXVj5w8yZbkypiUSqEvE6SSfxmzKHOf2K6Dap/ahrOYm0yaADVujLVzcQ76mHQu82Srn404U2T6hUDDsfRjzZixWV9TGdmf9dcG7dUnLENf4PugwP5xPM4obEhwp46JSSWUSKrVDw68RIWqVuXvOxJiPbJ5s9256rMvm5UI4u0rVaJSTZvy/Ucr/+QEjHckiEImZIxrXPNihklSZA6/f8UKKt+hA6+H/kbSKYy34nXrsmAFjUeMoN2I982Rgye5Lm/fzpmSMcG25KGHOJkf7k9YH/er9uPGZdrvqAjcTAIP5P/++ziVLv0xi7k//jhC33+/i+bO7UvVqhWxsyQpS96BA6kxQK5bcJNNH7BhsYRzJKy3X3xxDz/wIUspYmCfemoJJ9yBpRUWUMSv9ukzj1avHqjV53WHRYsO8uvIkWf4gTx37rH8kIhjQWzACnXixHMsoCBAYJXt1q0k/fnnZS2L79Sp91KHDvYPr3jA3LnzIpclQYzykCFNOOMqyvrgvFeuPM6CC+VFULpn8GDUKCU70YI2eILeIpkqXu1/LEqWzOsgcJUAUlZL7ANZXyHqIFKU5dOaRdn6Y4MHcvyWqdhJiB69KNGLFqPAhQVeZUoGsNpu3XqBjwWrlbE/ASxcelQtXLQREwFKBOotuErMKeFtFJcQV6q/jFmS9ZZVCE5cO/3415cRstaIdrSy4nz04dgQdGYi1NqOOJsFN7WvVKZhfe3c1GtlfZ8q4hOcWnDVNsYyQa5YcPX9qNqlRDbAdw8CV8UA4zsEEYj/rdbdONtYSu1fawyqVfArgauPwdX3gTGLsnGSRu9FAI8PtBdld3BM/XmjPM+UKdu4Vi3ucwpjySIcS39+CoydiIiXHSZJzFAZk+Ed8vPP++jnn63ZN/XgWrVrZ7UuYgJMgfuEnp9/7mdnXXv44XrUrduPfJ59+tzGya5GjlyeofuGr0DsEcr2IOlI+/btqUOHDj4TuGDKlCksbhE3h9nzGTNmkL+4fcIETv6C0h8QWhNz5qQBW7fSpa1bqdOXX2rrqVqd/f/5x/Sh2iWBaygTxJ8lJtLK4cOpeu/e/ECHB7uHN26k5U8+Sd+UK8ciqd4TT1CpZs3otz59qEitWlTxjjvcPk8Ihz//9z+6Z9YsfghGPUuVNZlLwhQtyoKas7vmzEkbxoyhHOXK0c2DqfHndQcOpNZvIrIwFTz8o+Ys6tMiQypqy+LBE0IcyYPwAAvhC7H0yKZNXEoJ7VCiAYI2pyErq6vAgggxAAGJ/RjFq5nANYpgLaOvSfZsdZ2ViE3UZVGGoIEYUsLkls1iqtBnUr60bRuLEiV4MDmCNqHPMLGgp3A1a9WFdmPH2vezru4ut9EWp6jPouyQLdogLlF6hxMaXb3K4wz/q3I8gJNMHT9uKtDUeaNUkJqQMMIiNQS/pRbTOrX6Pj9/9SqLe/Qh2q76Cvs3lvJR6DMcawLXREDrxaqdwDWZYNL6xkk/YrxoZZBU+5F93ZbNFwJXZRVm4Wv73JiFXV8uDNcRExZae/Pl475TEynGLMoYw2gTJlh4W904wzIkJIMQxfdOUaJhQ9r43nvU+q23qIRhjHHJM1uGaz6Wk0kl1J021tl1Bu4BVw8coGsHDtBt/fvzZISRSnfdxX9VewpXreqwrM4jj1Dthx7ifgDIiP3no4/Ssd9/5zH98Pr1tNWWm6F0s2aUmYjAzWTwEAeBC0sImDNnj4PAGDq0qUPNSVfAw78zF2U8tL3xRnu6//46bN1QoN7r/v3D6euvt2rC6NNPu1KXLrPpiy82ce1Od4BFavTo1fTWW7dr1h+4IJ45E8UPicrapB664Sq7fv0TdPXqHpo5839slXniicWa1VAPJgLwMIyHzh49atKUKamZRPGQjbI3SCz15JNN+MF12LDmdla+jKCEkpl41YsDWKuV8IMlWbm7AjO3XPWArUQlwLXHQ7pKOARRoiy+ys1Z9Z9e4EJMwCq/fLk1CYVy14RLPMQFyhm5grImo/0QgKodyvqmF2ZWgRTqkIRJ79JtdEHWW2lVfxhdlJUAjYiIp1q1innNgpsqcON5X/rviBLP+O7ozxECXFniXbXguitwsT76UD9eSpTIx9ZRTHigT+Ci3KlTFQchqrfgYjzpXdqtNYr1Ajd1soSzy+rq4Br3i3Goxhn2i2XffrudOnSwF4pbtw7h8W4s04Q2qdJG6Cccy1kogNHCn1afQeR/8cVm7l9VpskTjK6j06b1pPnz9/P1xsQZluNeDE8W47n5m/Pnz3MN3IG2TLNI1OFLatWqRRuQECdACLc9MKqH5v/efJMf0FCKRqGEiDviFnAWZZuASjYRuHgAxUM0XH711pN+y5bRscWL6eK2bZzhN1/nzlzjc81zz9HAXbvcPsctH37IVj9l4SlQsSKXB1JiBmJD/1DdZ/Fi+nfTJup63338AP1tlSpsFTIDLpBwTY45fZoGbN6cWmYnXz4uF7J35kyuY4vvACw4nb5IzS6eEbQyP1evskjWlwnSCwCIDpXkz8yCq0rj6Ou/6sWTqrdqtIpiP0q0pEDg6kSLvhbulo8+4kzQyhKmyvsc//NPO1GSFlwmyDY+0V4lArU6uIb6rc6Ei7J6c3Zng5BEfyprdrxBoHGd3EKFeMIC1kRjvWcF9qssuLB+mwlQtAHXDNeGrd26vsL+1XVNy4KrasUqIaQnLA2Bi2zOZui3MZYWMpbQ4fI8EREONWbzQGza6tXqr5Gx1i3Gkbrn2HkDxMfzd0ZfB1ctx3tMivC2BgvuoXnzeDlKFSkQzgBrKO4dRthrQd2TcCwTCy73RViYXQ3jtChWuzZd3rGDjv/xB1tqM4L+mta87z6e9Dm5bBk1GDKEPWnKtmnD9xNMCmYmrvtoCl5B1TZVzJq1W7M2KL7++l768Uf77GHuWnDNHrDHjr3TTtzqH3pfeqkN9e1bR3uIhPvw3Ll73RaIEOx4qH3iiSbaZxC6sBDD/U//MK5o1ao8HxMP9HBBhLAqW9bxoQQ/dnA5XL78GD32WCO7ZbVqFeeHepRcUlYb/EW8rjfQW3AhENC3RhdnvTjQuxGbC1x711v9MghVR1FiFSw3b6aw5VIvcLEMDwNff72FY53Rn3qBizha9D8mAVxBWdGN10qJQWRo1gtcM1dcWBhxHnBhNbPgqr5Cn+Jc9X0J11zVj1YLrqOLssqMnJ7AVXGs6B/0o/p+QEDrrbf6feOcrHHGqefoTJilWjJTxSqOZZxg0qMmA/QCFx4Xxu8rRDX6VtWfhQUXrrXWPsqnxecaxxL6QXkDGC24aryoewTGkt5F2V7gYhym9hG+e/AQGDw49bsN0G4zAYjPoCHVREda/egOtWsX5wm5/v3r2VmMMwruL/ffX5ddnNU1wr0Y98ZAY/fu3RyDWxXxljdvUmRkJGecRIbN7IByP1bAWoCHKP2DVpmWLeklF7PuO6uDm2JiQYLg1Itb/fhBjFm7d5Ej10r9J55g105VK9VVUCsSLs7txo3TPiuI2NTTp1m84SHdKHbwUJmzWDF++C1UuTIvV7UtjVTu3JlOLl9OtR580MFFGKI6Ys8eFsEAIrDOgAHkDfAADmuUmkBwZsFlK6/N0oq/ehFsdFHWW96wf4gJtRyWfqPA1Vtw9cID/QDxi2uFOMgmOo8IjhmuXJlOrVjhYMF1BvatrGl666pTyyMErknNV7iVQ6Aa69yqvtJcbHVC307YXb5sFb9OXH35O5OOizLawPVbMemg3Llt35F0Ba4t07nRyqlHjUHlaqx3UTbrE95GN1FgJ3ATEhxEsdGCizADPi9dXVpj/6Ef1ASFgwXX1l5tjBoELrtF266NcZIFlk94CNQbNIg9L/TbmIlbrf1K4KbRj+5QrE4dDrNAH6jvurco2bAhu1+r+3TVe+6h/mvXmuYj8CUicDMZvXBBYphXXmnDD1TewN6Cm34MYFrAnRUP340bT6GtW89rCXcUEKtI/IS/EJzqgfntt/+mMWPusHtYh0syhGfZshNZlKRlrWnZsjzNn/+A0wfX2bPvoz/+eJjuucfe3RbHe/ddqxuYL6wtegEKgWBWvskYg2t0YdaXAjImT4IQU0IAwkI/EaK3yMXGWm/kyh0XAhZCDHGTn3++mUaNsrfSKis6xBJEkSsod2mj5dU+yVTa4g+xnHi2VCLWeM0xgYHkYDhn44QHEgnhfNFXzpJMQUC6InARY3nxYqyJi3K8wzhRsdtK4KZacJ1bHpXVV2/BVX+dWXDVvjDGVWIqqyC2Xx8/Bnoha00gls9urEHoYyJB34e4fqkWXPsYXH0fKI+BvHlTj4v9Qvzju6x3UQYIG4Bbb+vWrrknog8xjlPLRXlH4CI5HTxRnn22JWUXTp48ST/99JNWL/DcuXOcbAMJpl588UWaPn06x8YuWrSIsgN6awoEU+1HHvGalVH/8G7mouwOeCiuO2gQ/di6NR2aP1+zIiluJSVxbBri1Q7Mnas9qG8cN46qdO1q59IHqxMsrgu6dmXriDO3UEW3WbOo4p13mi6DWzJcB9u9957DMlidQdnWrckX6AUqC1yDwMb1hDBSwg1WXr0IZtdfm/DAMjzw64WJEgM80ahzUeZtdVa5lNhYO+FRuEYNdtfc9tlnVOfRRyk/aqLpUNZcV8WAiuHkONgbNzTLmhJCqFGK66+45SS2Ml+ZMhzTqLdUK7iu7YUL/D+LWMOYwDkgntrofmv8nUnPgsttuHiRBSiXbbS5c3MfmwhcJcCMFlyz89P3Ca6lfhtXLbj6GFyz76xeyGJcIb6UPzfE4Or7j8eZEwsu9g+hr6zYRgGs37fRRRk5BO77809qMWoUuQqunRK4zsaJu5S//XaekOv46aeZLjwzC3FRzmTwwKcydyKB1FNPec+1zOoGqGJwnVuQXAEP7khE9dhjv1Hz5t/SpEldtQdKCLAOHWbygzWsQ3C5/vjjzuwijAdoPIAaRdaqVSe0984S9ihRoE8uZbYcWZ7NePPNDvTqq+3IFyi3XdzQjVYxZ/GLxvPUx9karW74H2IEEwlmogTXFWMmLu4WCzk1AQDBgNjpCRP+5XHVpYs1HkiB5RMn3k29e7ueZVVZcCGEzC249i7KZqIF1wmi3bmIzc/x1FbrrjEBVW4We9jWmGRKHQsTOK4J3AK0YsVxhyRTxgzKQN3kVWbh9M7RWQwuxKHqA2eeFuhbowXX7PuK2Hm43WNc4JqovoCVG5Zda21oq4eB2YSIYwxuqosyllnd6FN/3JS1HP2ud1EGaB8snJ669t+8aV4H110wlt0Zz1mBfv36Ub169ejtt9+mZ555hutBFi5cmC24c+fO5Tq12QllGcBDJpIgdZ8922v7xsO7ErhmLsru0vnrr9ma/Nejj1KZ1q3pwdWoKmkFiaEQS6wSOSEmDg/ZSFg0YMsWu/0oC64SA84EiwLJpNLCmYBFnN0LsFzrrEveRJ98yZiAx2j9Qlt4HZ2buT75Dz/0h4TYCSwWAxERfA0hlFy14JZp0YLOrltHp1etYndzIx0++oiFIKxT7lhwlZhXiZg065vFYuei7MwypwQuhLpxUgPLYJmE2EQ/GQVwvrJleVtMrBiXOXNRRoIkszZAzEHoaS7KNis7+tjYLggwFqs662palkc1pm/ZBK7qFzMPCuM2oSYWXKPVF+78SAKnWWpbtnSIwTVOIEDoI/s0QN8WrZX6XMoiXzeWzMaxnQXX4HECi6Y7KBdxb1pwC5QrR71//ZWyMiJwMxlYRGB1QykOZV3zFvoyQa7EAKYHHtphMUXM3UsvreAY3e7da9L//vcrx6UNGtSQhQIyGz/77FIWEWvXDnKwvqKUx7hxp6hly3K0du1jPp0t0scwehOIUwgJiAM8+BtdzZXAhehAP5hZCNOy4Kr/8bnRRVkJN4giCFyjuIbARcbqF15oZWr5fuEF92bi9fHAehGoxIlezGEixZlogYhVbulGF2UIT6v4dVyG8WFdHuPgoqxcR2H51Me8QtCZJYKCQMRxVJkgWJ6V27TRRVlhtODivVEMpxWDm57ATY1lTnX1dvZ9tfbhDc17QPUVBC5KKeFzbKf3KLC6KCdwu7Ff/VjSuygr8av/PlrdjXPzRI3RRdkT0F6VCdpbFtzsyK1bt2jmzJm0adMmTi61bt06/jt//nwaMWIEW2+zE8qaArdRCD9vkp6LsifAHREW2a/LlKENY8ey+x6yFB9esIBjZyP27+cHaCSZgaBu9uKLnKlUDxIdQbiBpxBH6GGiJ1fwlbjVW2DNLKxGcYAJBlwLvYDVW3BZrMDiq8sayxbciAh2T+b19a6lsODaRAlicPXLYJn97623OG4ZWV+N4Pq5fZ7R0RzbqU8OpYQZRKVRmDmz4CKDNtY3TmqwJRKlqWziLbeJBRcCF27EzuKxYUnWEkHduMHZdY1gkgDjEu0gm4syRLXK7mzM/gwBlmC04KaRHEldP6yjb09aSaa0xFQGV28zqy/68LStXJg+VjmP3kXZJAZXjTOzDNf6TMoc842xpMusrBe4rmZwdwbae8UWx+8si7LgiDxtZDIQRogz9Y3AtVr6rDGAGXNR1tOvXx0aMeIv6tfvF65ViSzLGzcO1h768ReukijHYyYysP2QIUs4fjCjottfKGsshBQEqJnAhTsphBREh1mMp1Xg6i249tZRLMfnRhdl5eqMY5sJXNSw3b//Cpc18aa1GmJQ30aIKgDxB7GSnmiBSEWCK7inI9GYo4tyDO3YccG0PAyE3aZN5/icMUFiBONNuc1DJGLcO3NRxnGUBRdgXbMJCIVKMqX2n5bl0SwGF9sDZ98/s2RdZi7K+vZjTFljcsO0yZT1689qEwR6kYpxhH5TkxTOsiin5YmA8AP0k7G+sbtYXe/j08yiLKQPru/FixepZcuWXKIH4lZZdj/44INs14UQNSGhoRxr6kuBm1EXZaMVqVqPHpwQK/LYMTr0889035IlVLFjR/488sQJFmdt3n7bPA6yRAnN0utLcetrUC8UQgriAK6lxnhqO3FgK4HjTOCaue2iDyF8ISwgLPViXZ9kirMo6y24rVqxCOw+Z45XJuHZUh0TYxVOujZqLso5cjjG4JoIF4hUZAjH+ZRqYp//AAISfYXkV3BhN5ZsgrBDvCeyb1fq3Nm0nWwBtblKo71mY4/jQ8uU4dJSnM3ZlmQKwhnCz5g4SgmwEBdjcLU+iI+3d1FO4/unlRYyseAat1FWcKCPZUbfYRICEynGJF3sKaDLomy00LIF1+iibBS4ly45uCh7gj4GN60syoI98rSRybRuXYEtuIhxdaXuozso10dYt6zJY7xzeSEEEhJGU7duc7iW5Pr1j9tZtB54IG23RWsG2BdM41aDBVgtIUAg/IyZaRU4P4goWL/MLbi5dImB4tnyanTnVK6h+v2rhFawvJkJXFjV8fIWykUZAkcvLj/44C4aOLAhl4CyTzLl3IL788/7eawgMZBxGVzbf/vtEM2c2dtUHCNjLxKwmVkRMcZVHLCzUkVqPyojucqEDC8HswkIhTsxuGlZcJ3VWTYXuOb9iPYjQZgxjlnF5polbVMuyqr+q36/RhdlM4GLYx46ZP0xNVvuqYtyWv0opM3o0aOpefPm1KtXLxozZgwdOXKEatSoQVevXmXhm92AlQl1WWsPGMC1Lb2JQx1cLwlcAGvtrqlTacVTT7GQgrhVFK5She74+OM0t39g9Wq6cfYsBTNKoEKw8XuDcNALXAgoCBm9Fc8ocI1WTeWibGZ1U26liH21JCTYHRtC+8ljx7x3njZXbGNsJ6yVD6xZw2JUCTPEYEMImo01FpZnzrB7esvXXjMVwKhDWvXee023hcCNOnmSKnfpYtpOWDtVLLCzGFx1nPMbNtglmXKWYEpZq12NwVWYxeCm56KM9lvScVFWlmxjMik1dnisGevg6soEGTMh68cSDEqaALYdQ/U96seabesu+tJYaWVRFuyRJFOZzH331aann25BzzzT0uvutMpFGQ/LwNvW0unTe9LGjU9otSjdAfVwnbl5BgsqhtaZBVcfh5u+BdfRNVdZu6wuyvbbqlq4sbGOAtfboJ3I7j1jxk67awZxhNq5rsTgKhH777+nqVu36g4z4nAdhlUV7rfGsjOgaNHcdPToNS4HZQYsuEpIqnhTs1I+6FMlNCH0UD8Xk0BmwjAtF2XnSaYc3baVu7EzK4B9kqnUbZxbcB3jmFOzUNvHKOsFrjFJlBLkaKdKImU2lvBdRa1p9FVGJ6XERdk73HfffbR+/Xou17NixQrq1q0bFS9enBo0aMB/f//992wldOGaee/cuVSte3e72DifWHC94KKsp/7jj3N8LRI9uQtEUZEa5jkogk7gRkby/3r3YkUencA1CigHF2UTCy6EL+/fKHBtLsoqBjijwiMt0E4kePq1Vy8HqyjqIuvjU1XNZmcW3Ii9e3lclmrc2GE5XJchgKv37Om4bdmy7C2AeGtkQtajSvKwBTQxMc0sykqwARWDq1yUzZKdKSGrj6dN9sSCm0aSKeWizO23JZmC2DSblELbMZaQ7ZjHlK3NXFanWDGKOnGCJxj0kyX6MkFmVlhOtBUba022lZLiMJbgZYGMzWYTLe6CMa4S1HkrBjc7IAI3C6FclNNzkfQUWHYqVXJ0J8ouqNhGZzG49gLXMcZTn2QKdYHRn0Yxpiy4xv2rWrhmFlxvY3VRTnQ6SaLPoozJlPQyDGMyxwjEJvpq5sxeppZLeDdAXKGWsRlWC26qwIXQNIs/RsyuyjysBBu+I7Aeq8+NWJNMpQpWq2ttTjdclNMOD3DmomzW19YY4hiHCRG0HeeA8WIU6moixZgkSj8JAJHvXOAWoP37I3iSJaOuevryWhKDmzEqVKjACabmzJnDFly8vvvuOxa/U6dOpcYmD79C4LgoK/BQrc+OnN3gTMY2C65Z/K3RgmsmcFUCKQg7Y7ZjLQY3KsrB/ZmtbjduWMv32FxtfYVe8MBFOM0SOjaBaxqDW9ZW9nDkSNMashU6dqTKXbuaWmjVZIhZhnEt03HOnC5ZcPUCVyVigwuuWVIq/b5dicFVwP0WoQcWF8oE6esJa5Zw23kYJ6UwJtBuxCobY5nR/qv79vFyvRDVT6Q4s+DCTVubLDHU24bAhbeFV1yUDUmmJAbXNcRfLAuBh3w89KaX5EbwDCUcYGF1Jo70FtzatUuYJpmCsDh4MIKaNi1jau0yc4GG2MBxIXAzGheZHiqOesKETvTgg441/1zNMPz0083pzjurUL165rXdLl16yWkbUHv05ZftSx4ZhR/ie9PKoKx35z13LobFGoQqxB0yE2MfZhjr4EIQp+eijJCA9BJGmQlc+7Je5i7KyoKrt9TCyorjYBwZPQHQF7gPWC245rV+lYU3LQtuWuW8XAV9/88/p/h/EbjepUiRItSlSxd+CT4SuF5KMiXYx+DGnj/vUKPWWQyumcBV1saLW7ZQjb59HaxdSuAaLbg4HrLmQnSE5s3r04SXqp0Qnx0+/NBhuVH8ATMxB6HU5/ffnWbFvvOzz5y2AfHpL6akmJ4n6qBe2LTJ2g6dwHVmwUUMOMC++DsSF0exCQkcW56WBVft21MXZZfKBBks4cZJKXgJQMjCEo7vs77sVIGKFenyzp08zvQTCJxk6sYNFsQQumbu7liOsYT+MCZmy1++PMVeusSTARl2US5RQrMWuxLLLFgRC24WQtXBxcMy7mfOYgAFz7BaYBPScVHOm4aLci62qs2fv59FhNGCay39Emu6f6vF7kamWHBhfVaWV7PzNLrvOrNWQiAhhtYT0nrwOHbsWS5bpSy4mHQwS25mTBAGay4EHgQu+hK1ejPqoqwEI9bVuxunJXCVNVh/DGcuykhEhzGBOFy9kMU+MJmyY8dF0xhciFdMlBjHCqzc6A8sMytlBTA20afOYpTdQdU7Ts8SLgjZxYKb3dG7KLtiwVXldRRKnCCrLAQayvvYbWvLjIv9Gy24cG2H6IAoyeFD661e4Fbp0oVK1LcvnWjmvgvLJT4z+y2sdu+9ptbbjPyWohQSsnFD8OmTTBktkdr5KJFms+BCbMGCq2rKplcH16UkU0rg2lyO08pirk+opRfEwOw7C7GPZF2YANH3CT6/vGOHg6s1x+BGR2tWXGOdW4zdxKgoawZlkz5j4W+xsDA1i1N2B7iXQ8gjjtgVS7hgRRRQFkK5X6oauFm1eLO/0Lt+OiufYu+i7Og6itqvTzyxmKpWLWIqBmBpNNs/xBiscjduJPtc4EKUNmxYymn8paviz1eg79AHsLAi5iY9C65aBoGLa4AJBJRzMrPCQ2S2bVvBjRhcax9BbKfnbuwYgxvCrtZqG2d1cPFCLV+jpRYJwLZuPW8ayw1PALMYXIBxiRjktCy44K67zMtKuEO5chjT0elawgUhUMDDO4QtLDfeqIMrOE8ylZ4F18xFGUIP12TeHXfwfoobxCPiTp1ZiGHFgyjDMlhwfQmshvnLlaPqvR2TKPJ5uCn+vA36BtZhdlFOTLQmS0rDgqsEHrso265hrBMX5XLt2vFfhzJBLsbg6i2yTpNM2a4f9q8EsTMLLijZpAmdXLbMISkZSvhctAlfo1sz9oc4amAUsRiXKAFllmGZz10XW44M1xkBfa6yWEuSKdcRgZuFUHGasDKm9cAveAashGmVCVLiAGVxYME1rqOsjPXrl6Rvv+1huq1V4Dq6KCsL7unT8VSrlnezbxtBIqmdO4c6Xe5vgavcpAHa4Y7AxTU5duwaJ7gys+DGxLxGs2b1cThHZ+VtsB6uTd26JQ3WWOd94iyLsjNR3KxZWc5q3LhxGQfrLlyjmzSx/xyCGJMhZjG4ABZfjE9M1qQlcPv2rU0ZBZM2OBY8S8RFWQgGlIWQXQJh0XLywC94hiq/kpYFF8ILAhdC1WwdJWSQVdrBNbRcORZsSK5kdFGGGIMoi9i3j8IzodTS0LNnuZSVGUr8QVj6M3GQclHmSZ1bt5yOdyXiILZgGcf1c2bBbfXGG/RCQoLLdXBBvccfp1ajRzvWwU0nBhdt1yzhCQncPrPEZYh7R1bjkoZcBVxmzGJxKMEEAYu+uX7kCI9ZowUdFl+40LP7chouyOVvv90rxiY1cSMxuK4jAjcLoRLSOLPcCBlDxdAa69TqqVWrOB06FOEkyZRVaPXufRvVqOEoUlEn+OzZaKcuymfPxtCxY7HUokU5v15KfY1YWB79I3CtP2Cw4qYncPUuyrBeIm4Vws6s3dgv3Hj1ccbplbe5ePElFnKuxuC+/XYHLrnkiosyQKw2xhJKi+lRsfZGN3Crtf+G0/sABG5aFlxsv3btIK+MM8Tg4jzhpiwCVwgGIKjwUH3jwgWr+2EGE8QIaVhwnQhcuHdCaCHGNi33Tn2ZJb0FHttAxJq5KEOUXdy8mfJ6Ofu2uyh3ZIhKtlT6SeCqOriqJI5TC67te8DJmIoUYet67MWLphZcCDpYXu3ijNOJwe06fTrVf+wxl8sEod1Nnn2WhamWZCoNQVyqaVP+W/d//3Ow4IJKd91lfw45crAnwfXDh009DSBwb6ZhwQUDd+2i3r/9Rt4AAhfWZInBdR0RuFkIWF4gkJxZbgTvuCjDIuVsAgHZf5H8COIBgtV+e+s2NWoUdXr9kF0Z5YCMLspWN9VjlCtXDqpe3Xz7zCKQLLgQ2u5acA8evOo0SZiZiHflHLG+tf60JU1rLMD1e+WVtg5ZlJ1ZfR99tCFNm9bTYbkaR8a4VpwbXJQhYs3uAxDLWJbWfaJ9+0pemXVGn6PUEdyUReAKwQDGPayAMadPp2udETwXuBxf62TyANegSM2adHnXLrbmmmEWr6pP8IPMuMbJCQhnCK3Tq1dTnpreqx3vCar9EGf+tuAiizKs6lwCyEk7zCy4zlyUTTNFu3iOmmU7JYW3dZZkCtw5aRKPJ325JWcCt3i9etTxs88467SeQlWq8F/j52pChC24JvcATKJA4KZV57ZEgwYOkyyegnsSBK6UCXIdEbhZCAgqCDA8TDqLERU8BwJ1797LLA5gqTUDljwIjoYNS3MspP324XYuoGbbwuUUOFpw87MgqV27gN9jq40ldLxdjsoVlIBUFlyzZEnmAjcXW3CdJZjyVMSrhG4QuWlZY43bpMbgQhTncBpzjPrZRj78sDPFxb1uGgeOcXT8+HXT+4DVRTmeJ1Mw5nwNjnHihDXjtTNXb0EIJAqUK8fujPgiZbTEh2AucGFFhehwBgQurJsVO3UyXa7K5zgTA8AYb6ksxhAlefxcT1jVoYU4g/jzV6y3SjIFCy674jp5vtALXPQjSjQhk7KZi7JC726c7KbAVaWL0usXjtm1xeByzLwTQQy35abPPefgvowJlGdv3DAVonltAtepBff6dWupqjTGordgCy5icCXJVHAIXNTxa9OmDdWsWZOaN29O+/btc1hn9erV1KJFC6pTpw7VrVuXXnnlFUpJsT54go8++ojq1avHy/v06UORkdYHKYAvav369alRo0b8WrduHWVlYJnBg/iBA1YXTMG7QCgtW3aM2rev6LR/IaJgxb377qqmAhllcxBTaYYSUbDWGhM8KYtj+/b+td4GjgXX+iMFMZlezLmynON3Gy7KSAKG5Edp4RiDm9MlgYtt0nNRVsAV2tW4XWfbm7UL+8EEyeHDV51acOEyfOzYdYdSVr4A2cIhtoEkmRKCAQikqwcOpOmyKXgG+hPxtVf27DGt3aooWqsWi1yzGFbEeN49ZYrTbeMvX+a/xv0r8YayK75OMhVUFtzERI43T2usa54MFgtbL3ENIT6N2Yft9u1GDK5+G8TUwt0YpFemC9mnXXFRTotwXdkgB4F7+HCaFlzcJ4rVzni+ivRAkim24LpQbkkIAIH71FNP0ZAhQ+jw4cM0atQoGjRokGmtv59++on2799P27Zto/Xr19MPP/zAy1asWEEzZsygDRs28PKmTZvSG2+8Ybc9RO3OnTv51b59e8rK4OaNB/f9+69IDK4PQHInuMaaWdP0vP9+Jxo+vLmp+F216n9plrRBzdgvv7zH4fMKFawziG3bisBVGYg9dVFOy4puFLgo/QMrsasWXGyTXhZl4zFSXZS9ZwnHJAkSljmLwd28+RxbUytU8L37ZfHiebRMyiJwhaARuPv3s0XLLGGN4DlwE0aG2gp33EF50hBHdR59lDp9+aXpsnZjx1KVrl2dbluzXz+qcd99plY5XNO2Y8aQv9ELXLbg+jnJFFtw0xC4SuQh+ZqyhMP6mZZHmV0pJBeFmbL6whrrisDlY6Sk8MvbZb0wVmE1TSsG99qBA1Q0EwQuvjM4nsTguo7f/MUuX75MW7dupeXLl/P7vn370ogRI+jo0aNUvXp1bb3GuoxnuXPnZkvsyZMn+f2uXbuoXbt2VMCWvrtbt250xx130OTJkym7ggd3CNw6dXxvmclu9OlTm27eHM1CKS26dk0dv+6yZ88w08+tbqdv07Jly8jfWONTU4WZP0QLflQx2WB1UU5yqCnsTOCqxF/pWXBhIca+Yb0F7ghcVy24xizK3vS6gMVfJdMyE7h79lzm5FWZ4e4OqznuSeh/qc0tBAN4cN8/e7bT2DrBcyA6h8PCquJxnFC4alV+eULL115zuuzZaOtkm79/SzWBm5TEYs7fWZQRg5uWBVeJXwhhlfhLuYKnte9bHsbgumrB1frx1i2vl/VS7temFtyiRdkqjWzdmWHBZYvx9etssfbXWAk2/CZwz5w5Q2XKlKEw2+DEg1bFihXp9OnTdgJXz8WLF2n+/Pm0ZMkSfg+L7VdffcWflypViubMmUMxMTF07do1KmqbGezUqRMlJyfz3/fee4/yGVwRJk6cyC8FXJy9deO7efNmpt9Ec+SI5RIhV6+e8/sNPND7KhgJhH7as+caXbtm/Z6cPXuBjh1LoGXLUkMDMgsYVtasWUvHjp2hPHnQnnjTvjp27Cq/X716FZ04EcX/R0ScoGXLrA86ZkREXKa9e+Ppzz+v8Pt169ZQ7tzORWtiolWoLl++knbvjqDIyJh0r9PBg5fp0qWrvN7x46cpPj63165t8eLWh4ODB3dRWNgJu2WnTln7o0iRJD6er8dURMQ5TuyVM2eINqEZrATC90/wPUhShGy7xerUke72ATyx5udcEv4GQiUQLLj6GNy0BK4qk4P4aa4Ja0vGlhZ2Flx3Y3ATE60lf9JIJsbtMmajTkcQu0Pp5lZPPLN26zOAp9cP3kBZjDHRIC7KrhE0GT+io6OpR48eHIPbrFkz/qxjx4700ksv0b333kuhoaEcgwuUaD516hSL5tjYWBo6dCi9/PLLLIj1jBw5kl+K8uXLU5c04kLcAQ9C3tqXq/z3Xzg/9DdqVJu6dLEW2w4G/NFXwUgg9FNy8mH69dcobseECRepSZOG1KVLw0xvR+7cO6lly9Y0f/4Nat68DnXp0sRJXx1FxD/dfXdnKlz4HI0Zc5i6dWtHbdval9fRM3PmDapevTS1aVOfiLZRjx73pGm5t1piN9Ptt99BJ0/uoqioi+lep/Pnd9DevXt4ve+/v0F165by2ne2ZMkLtGDBVOrQoa1DzHfhwmdp3LgjNHlyf44X9/WYOnVqG/3660oqXDiP38duVvj+Cb5HWQ7Fgiv4UuQrMcfiz09JpvRZlFm4poPKtgy3XVcEricxuErguiJWVQiBto0X+7Fs69b8N2LvXodlqv5y+wkTMsUTii3G8fEc++zKdRL8KHArVKhAFy5cYOsqBCnKa8B6C0FqBFbZrl27Uq9evezEKBg+fDi/wMaNG1mgFrS5E6h9wWqLdRDvm9WpVs3qOiJJpoSsnGQKwEXZlSRT9i7KedyKwY2Pt5b8Sc8tXcUEW2Nw0y4TZDxGemWCPKFRo9L00UedOabbSMuW5Skp6c1Mcxe2Zm2+SU2alMmU4wlCRilcrRr/VdlZBcEXKAsnxJ9f6+AmJlotsy4kVFP1cuEy66yEk6nAdTUG15Y0CtbYtEoE6Y8B1DbeFLgQ8n0WL6YCFSqYLh+JMkbpWJi9hXILh5tyZliMswJ+SzJVsmRJatKkCc2ePZvfL1iwgMWp0T35xo0bLG7xGj16tMN+IJJBXFwcvfXWW2zhBdevX+fPALIuz5s3zy6eN6tSrZrVNVvKBAlZX+CGupRkStUNRtZhxKZi3bRidvV1cF09P56NzxGiJZlytUyQPgbXm0mm0J6XXmrjtO2ZGQvratyzIAQKKqlMfESEv5siZGFUQiV/Jg5SFtz0XJRBWN68VPHOO7WyNYWdhBNmtA6uxQ2xGmIQuN62hFfr0YNKNmrktK2ZORHB1yckhJNfCQHuojxlyhTOnDx+/Hi2uiIjMhg8eDD17NmTX5MmTaLNmzezm/HChQt5+f33369lS7777rtZwCYmJtKjjz7KiarAwYMHOUszHvRgJYaYxr6yiwXXFQuSIHhD4PqjDi5ITTKVtsBFzVsk6FL/nz8/Mt3vB/ZtteAmuVy7NdXq69o2+n50NTFVMAILLhCBKwQbInAFX6J3UfZXHVyVZAqv9Cy4z8fGav/3XbqUcqZTaon3rbPguuOi7M76gEVxYqJLVt9gBW7KHINrc48WAljg1qpVi0v8GJk2bZr2P4SssfSPnj179ph+3rp1a9q9ezdlN1AeBMTGWpPMCIK3UdZNNc7SEpe+BILQFQuukbTKNBnFZ1xckkNN4rS2QVkhuDWblecxX9/iExflwBS4kpFWCC5QekQQfIWycKL0jr/qLSPOFWIS1k/UfXUVV9yZ9S7KSXFx6QpibRtkRI6Pd219FYOrkkz5aaIgM0BZLZWcTEifrPlElY2Bxfq33/rT3XdbY4gEwReuwcryGBub5DeBq0r5uCtwXcFTgau2URNNaQGXaV+5KAcSKu5ZLLhCMDFw164s/bAs+B9l4YTAzVOsmP/aEB3NLsqFbLHnXtu3PgY3Lo5dnF1xOYY1FoLYFQsuZ3cOCfGZi3IgkatIEUkw5QYicLMgPXvW8ncThCyM3rUW4jJfPn8J3BzsDgyLqStWWU9q/WLf7gpcV7fJLi7KBQqEcxKusmUlBlcIHko0aODvJghZHCUAuQatoYRlpsbgqiRTXs7OyzHGcH+GdTUx0XULrs1F2ZX11TbZxUU5b4kS/m5G0CACVxAE924aNmEG92AIM39acJGdF3i7DRDPsE57asF1NwY3K7sow6ukV6/bqH59193fBEEQsjpKzLmS4MmnWZRVmSAvt4H3bROrIMwdgeuiBVe/TVa34JZv357yueFGnt3Jmk9UgiD4DCXMIABBvnz+SXgAi+f16/E+aYO9WHXXguuaKFYxuyqW2VUhHYwsWPCAv5sgCIIQUCjLI8fg+suCGx7uchZlT7NEw90YuJNkKglJptyw4MJKjH50dZtgpOlzz/m7CUGF38oECYIQnCj3XbgnA38JM1hZYcGFtRTxrN7EXbHqiSiG264+ltlfEwWCIAhC5gMBeMtH1tNAsOBqdX7j4zlWFgmtfGHBReIlf08UCIGHCFxBEDy04Fqtjt4Wl+65KMf7xEU6I0mmPInBRV/6K5ZZEARByHw0a6UfsyirMkEcB+wDgauJ1bx5OVzF1SRT7sbgav0oAlewIQJXEAS3UDViY2IS/Wp1RDuuXbvp9QRTeiu1VeCG+TQGNyXFwqJYLLiCIAjZB1hPLYGSZAoWXC8nmcqhLNQulghS2yi3ZndjcEXgCnpE4AqC4BYQZiA6OsFvCaZ8bcFVpZB8H4Nr4WMAseAKgiBkH1SMKotLP1twkUXZ6xZcm4D3JGFUspsxuBZbDK5YcAWFCFxBEDwSuFFRN/0qypBk6to137oou1MmSMXUuiqK9a7eQCy4giAI2YdAsDwiLhbiFgLRFzG47opVxNO6HYMbAP0oBB4icAVBcAsl3i5fjvWzBdeaZMo3FtwcXALJlzG4iF1W2aghjrNqHVwhePn888+pXr16VL9+fWrQoAHNnj3b300ShCwDBFxCZCRbUP0Zg3vz+nX+3ycW3JQUq3XYTRdlt2JwbaJYBK6gR8oECYLgFrA0QpCdOxcTIC7K3q8Lh7jemJgEjqV1R+Cmxu26Z8GFJdyVBByCkJnUrVuX/vvvPypUqBCdOXOGGjduTK1bt6Zq1arJhRCEDJKrcGGKOXeO//dnHdyE69c5y3FY7txe3beK6Y29dMktgctxyZ7E7YoFV9AhFlxBENwCQqxw4dx07lx0ACSZiqcCBbwvsnF+kZE3XU4YpQSrcjd2NckU6uBKiSAhUOnUqROLW1ChQgUqXbo0C11BEDJO7sKF6YYSuC6643obWFnjr11jMertSVa4PEM4x1644FkMrhsuyhKDKxgRgSsIgtsUKpTb7xZcuPRaLOSTNhQqlIuiohLcisGFYEVmaeCJBVcQApmVK1fS9evXqXnz5v5uiiBkCcILFWKBi7hRCEF/wLVpLRafWJBxTuEFC1oFrjvW2Fu3tNJCLm8jFlzBgLgoC4LgkYXz7NloqlTJat3xlwUX+Ebg5uYkWu7E4ObOHUZXr8bx/64kmYKbN7IoiwVX8BdwNz5y5Ijpsh07drDVFuzZs4cee+wxmjdvHuVzksRl4sSJ/FJERkbSsmXLMtzGmzdvemU/2QHpq+Dqq0tXrlDUwYNkyZnTb225sWsX/00KCTFtQ0b7KSU8nE7u3k058ud3aT9Xjx+nmFOnKPn6ddp78CCdcWGbmNhY2rZ5M7sob9i6lcLPnqXsOqaCgZuZ1E8icAVB8Ejgbtt23u8xuMAXbcD5wYIL66qrArd48bx0+nQU5coVSjlyhARNNmoh+7Jhw4Z019m/fz/de++99N1331G7du2crjdy5Eh+KcqXL09dunTJcBvxIOSN/WQHpK+Cq6+2Hz5M/y1eTPmKFfNbW87my0cn8JtXqpRpGzLaTxfLlKGQ5GQqVa2aS/s5GBVF27ZupcScOal527ZUxYVtrhQtSnVr1KDTFgt16taN8pYoQdl1TAUDyzKpn8RFWRAEjwUgRJ2/UMf2lYtySoqFrlyJc7kObsmS+ejUqSi36uaqesJSIkgIRA4cOEDdunWjqVOnUufOnf3dHEHIckmmEqKiKE/x4n5rgzo2yvP4glyFCrkVg5u3ZEmKu3zZrRhcuCgnRkfz/1ImSFCIwBUEwW0KF87FfytVKuy33uvatTr/9UV5nYIFred38eINly24ELgnT0a6vL4S5hcu3BALrhCQPPvssxQVFUWjRo2iRo0a8Utc8ATBe0mmQMFKlfzWpUVr1eK/l7Zu9Z3AvXjR5YzISuAmuRGDi2RWENEUEuKyKBayPuKiLAiCRzGqwJ8xuA0bltJcfL0NatRCgN64kehylmYIXLgoV6lSxKX1YemFkD5+/LpYcIWAZMWKFf5ugiBk6SRT/ha4yJyct1Qpirt0yWdWan3JIFcELmJpbyUmsnB1aZvSpSny+HEW0VJuT1CIwBUEwSMXZX9bcPFDtn//cJ+1QZX8qVatqEvrlyiRl+vg1qxZzOVjlC6dn44du06NGnm/lq8gCIIQuASCBRc8tm8fJcbE+MyCC4rUrOnS+nmKFuXsyyj7U6hqVZe2yYfyZX//Le7Jgh3ioiwIgkcCFzGkZcr4pzi9onbtEi67BLsLShCp7MiuWnCtbSrupsC9Ji7KgiAI2Qxl3SzkZ4Gbp1gxKlS5sk/2jTJBoGjt2i6tD3GLuODC1apRWC5rqJArAjfq2DERuIIdInAFQfBI4FaoUJBdeQXPBS4mCK5ejWehKwiCIGQ/getvC64vUZbhIjVquLwN3JRdFcQgf5kyFH/1KgtdQVDI06kgCG7Tpk0FGjmydZbvOWRTdpUSJZTAdb1EgRK2TZqU8aB1giAIQrCCuNQWo0ZREVuip6yIiu111RoL8pQoQcXcELiIwQUlmzTxoIVCVkVicAVBcJvq1YvSiBEtsnTP/f77Q1SxoutJtJCMavTo9tSoUWm3BW7jxjLzLAiCkJ1AHonbJ0ygrEz7CROoeu/ebm3T4MkntezOrqAst6VE4Ao6ROAKgiCYcO+9riXF0D+svPfenW5tAxdliOhixfxXT1gQBEEQfEHhKlX45Q61H3rIrfXhogxKNm7s1nZC1kYEriAIgh9FdLly1iQcgiAIgiC4n6m5x88/U8mGDaXrBA0RuIIgCH4Cltu77nKtFIIgCIIgCI7Uuv9+6RYhcJJMHTlyhNq0aUM1a9ak5s2b0759+xzWWb16NbVo0YLq1KlDdevWpVdeeYVSUlK05R999BHVq1ePl/fp04ciIyO1ZZs2baKGDRvy/u+88046d+5cpp2bIAiCIAiCIAiCkI0E7lNPPUVDhgyhw4cP06hRo2jQoEEO6xQpUoR++ukn2r9/P23bto3Wr19PP/zwAy9bsWIFzZgxgzZs2MDLmzZtSm+88QYvgwh+5JFH6LPPPuP9d+vWjZ5//vlMP0dBEARBEARBEAQhiwvcy5cv09atW2nAgAH8vm/fvnTmzBk6evSo3XqNGzemqlWtLny5c+emRo0a0cmTJ/n9rl27qF27dlSgQAF+DxE7a9Ys/h9iOCwsjDp27KiJ6d9//51u3ryZqecpCIIgCIIgCIIgZHGBCzFbpkwZFqEqA2nFihXp9OnTTre5ePEizZ8/n+69915+D4vtypUr+XOLxUJz5syhmJgYunbtGu+nkq54NkRwwYIF6fz585lwdoIgCIIgCIIgCEJmEzRJpqKjo6lHjx4cg9usWTP+DNbZl156iQVvaGgox+ACJZpdYeLEifxSIIZ32bJlXmkzrMXe2ldWR/pK+knGlHz3Ah25TwmCIAhC4OM3gVuhQgW6cOECJScnsyCFBRZWV1hxjcAq27VrV+rVqxeNHDnSbtnw4cP5BTZu3Ejly5dnSy32c+rUKbt9REVFUdmyZe22x/70+8T2Xbp08co5Qtx6a19ZHekr6ScZU/LdC3TkPiUIgiAIgY/fXJRLlixJTZo0odmzZ/P7BQsWsLisXr263Xo3btxgcYvX6NGjHfYDkQzi4uLorbfeYguvcl9OSkqiNWvW8PspU6awBRhxvIIgCIIgCIIgCELWI8QC06mfOHToEGdOvnr1KltdkRG5fv36NHjwYOrZsye/xo0bR++88w6XCFLcf//9WrZkrI+MyYmJifToo4/Sm2++yfG8ANmVkVwKbmWw3CIBFSzHaZErVy4qUaKEV84P4jx//vxe2VdWR/pK+knGlHz3sst96sqVK5SQkEBZGW/9lspvg/SVL5BxJf0kYypr/476VeBmdWCRPnv2rL+bERRIX0k/yZiS716gI/cp6fNARsan9JWMKfn+BTrlM0kb+bUOriAIgiAIgiAIgiB4CxG4giAIgiAIgiAIQpZABK4PMWZ8FqSvZExlHvL9k36SMRX8yPdY+krGlXz/ggG5VwVWP0kMriAIgiAIgiAIgpAlEAuuIAiCIAiCIAiCkCUQgSsIgiAIgiAIgiBkCUTgCoIgCIIgCIIgCFkCEbiCIAiCIAiCIAhClkAEriAIgiAIgiAIgpAlEIErCIIgCIIgCIIgZAlE4AqCIAiCIAiCIAhZAhG4giAIgiAIgiAIQpZABK4gCIIgCIIgCIKQJQjzdwMCjVy5clGJEiW8sq+EhATenyB95S1kTElfeRsZU5nfV1euXOF9ZWW89Vsq41P6yhfIuJJ+kjGVtX9HReAawA/y2bNnyRssW7aMunTp4pV9ZXWkr6SfZEzJdy+73KfKly9PWR1v/ZbKb4P0lS+QcSX9JGMqa/+OiouyIAiCIAiCIAiCkCUQgSsIgiAIgiAIgiBkCUTgCoIgCIIgCIIgCFkCicF1k5SUFLJYLC6vf+vWLXcPkW0JpL4KCQmhHDlk/kcQBEEQBEEQggm/CtwjR47QwIEDKSIiggoVKkQzZ86kunXrOqy3Z88eeuaZZ+jSpUv8fty4cXTfffex2HzppZdo6dKlFBYWRsWKFaNvv/2WqlevTidPnqRq1apR/fr1tf0sWLCAP/OExMREOn36NCUlJbmVZOPw4cMeHS+7EYh9lTNnTqpYsSKFh4f7uymCIAiCIAiCIAS6wH3qqadoyJAhNGjQIJo/fz7/3bJli906cXFx1KtXL/rhhx+oXbt2bOW7du0aL1u8eDH9999/tGvXLhYjY8eOpddff51+/vlnXl6gQAHauXOnV9oKcYv9QUTDuucK0dHRVLBgQa8cP6sTaH0FK/3Vq1f5umPCRBAEQRAEQRCEwMdvAvfy5cu0detWWr58Ob/v27cvjRgxgo4ePWonKH788Udq1aoVi1sQGhqq1daD0EQNpJs3b7IFFyLJF+UXYCmG5RbiFsdxFbi4or1CcPYVrjcmU3D9xV1Z8BbXrsXTxo1nqVu3GtKpgiAIguABB378kW7r359CJJxMCCSBe+bMGSpTpowmGCFW4Q5qtJjt37+fCwLfe++9XFOvQYMG9Mknn7DI7dGjB61Zs4ZKly7N1tVy5crRP//8o20bGxtLzZs3Z6tv79696Y033nAQURMnTuSXIjIykms0GcHxYmJi3BI6sAJGRUW53TfZkUDsKwjb+Ph4WrFiBQUKmMwxG59C8PTV+vXXaM6csxQa2oACgUDtp0BE+koQBCEwnhn/eOQRKtu2LRWqVMnfzRECkIBPMpWcnEwrV66kjRs3UtmyZdkFediwYezSDAvw3r176dy5c+ze+uqrr9LQoUNp9uzZLJ7xecmSJdkK9+CDD7IwfuWVV+z2P3LkSH4pYAE2FiCGQEZ8KI7hjpURgg2xxUJw9hWue548eeiuu+4KGOuyP4vTb9t2niZP3kLffdeLggF/9lVaxMYeoN9+iwqYtgVqPwUi0leCIGSUue3b031//EG5AigsK+hQyV7dSPoqZC/8lia2QoUKdOHCBRawajYG1ltYcfXgfceOHdk6CyvvgAEDWOwCxOXeeeedVLhwYbasImEVLLoAVl+IW1C0aFF6/PHHad26dZSVqFy5MtWqVYsaNWrEr8GDB3tt30johT6rWrUqNWzYkC3nmDxAXKqywPfs2ZOTeOGF469evZqXIVkYrtWsWbO0/S1ZsoTuuOMO7T2Ww1oOrl+/Tp07d6bnn3+exwHWq1KlinZeeImFyf+cPh1FO3de9Hczgp6UFIv8JguCIGRD8Ixz7t9/KcH2/CN42I8pKVp/CkJACVyIzyZNmrC1VWU4hvXUmNDngQce4MRTiK8Ff/75JwsuAPEFUYUMx0pE1atXT4vxVRmPEae7cOFCaty4MWU15s2bx4m08Jo2bZpXyu4gsdftt9/OAhqZrpHEC9Zy9Dus4gBWdEw8IMM1XrCy669dpUqV6K233tKujTMwydGhQwcWuJ999pmWwOvTTz/VzgsvsTD5HxFm5tSpM5kiIuLc7Ef5URYEQchuiDAzZ/Xzz3NMrbv9KLPFgjP8WuhzypQp/KpZsyZNmDCBZsyYwZ/DEokMycqCC7fkNm3asBURgvabb77hZU8//TRb+pSFcdWqVfT111/zsn///ZcFLZZBSCNOFzG4WRlYTiE6kbALVtXNmzfz5ACs3M2aNeP++OWXX7T1YRVF8q6mTZtSixYtNOs3EnsVKVKEBapyzUWpHIha9DNAPDSs6orixYvbWd9hdUW/T5482Wl7T5w4wUIalmGj67gQeGQHYfbTT3s5AZQ7HDp0laKibrq8vkwUCIIgZE+ygzC7dvgw7fjqK7e2iTlzhm5cuODy+tmhH4UgjsGFe+2GDRscPjdaIh999FF+GYEbMuremoE6uXj5Ajzkx8SkbZkE0dEJFBKS4NExChQId6kcEWKLEScK4KK9adMm2rFjB/ctXIAheGH1Rkwy6g1DdGKyAFbtd955h0UuYouRvbp9+/ZcP3j79u3UsmXLNI87atQoeuKJJ2jSpEmc5RqlnCBW9YwfP56ts1jPDFhtUdMY5aKMCaZeeOEFbp83ahgL3iE7CLNFiw5S06ZlqFWr8j7rl+wwUSAIgiBkTwvupW3b6MDs2dR4+HD3+sWNPskO/Shk8SRTgQjEbaFCE3x6jKioV6lgwVwuuSjDWqosuBCvELdg/fr1dPz4cbrnnnvstjl06BAdPHiQRa1elCKOGXHQZsd4//33WYTCmv7kk0/SQw89RF27dmWrL2oRQ+Bi2csvv6xth3YgTveDDz6g1q1bO+y3e/fu9N1331H//v0dlsFFGZmvhcABwgyvrIy74lOt68422WGiQBAEQUjD8qj+ZtFzdFd4urvN/9s7D/Aoqq+Nn3RKCr333juodJBmo6vYEP+iKHw27NgVK4JdaQoiAkq1Ib2p9N57DYROICE92e95z+ZuJpvdzcyym51Nzu95FjY7/c6d8t7TxIIr5IYIXDetqxCg3swMjG24Q3h4uO07bhYNGzZkoWvPvn372IIKd2R74MoM4am1EuMzZMgQLr2kgBuzspSjHBMstlqBC2CFhZs44nntgfX3rbfe4izFyIpttizKQsGzPLpjjdX+rwe0YX5vR0EQBKFgWh6NWmPVMjbRqmsB44PLQsHCpzG4/gpch2Fd9eZHj3tybsCaizhXJIBSIGETEj8haRN+37lzp20aYnbB/fffz+7McB/WJqpC8ikFEnqpv3GDgVu0IxdilHZCTDXEryMgchEHDAswsikL5qUgWB6NinglbI27KLuzd4IgCIJfUwBiR9214Lrjopyf21G4MUTg5mNgYf3rr79YXMKK2qBBA64VnJGRwRmPYb1F/Cum1a9fn7MYg6JFi9KaNWs4gzLmg0UXYhmJpFRc8+rVqzk5lSoTBHfnr7/+2uF+YJsqC7Yj4I4MkXvrrbfayhAhBldbJujnn3/2ShsJ+hELruM2AUZFcX539RYEQRByIhZcD8fg5mNXb+HGEBdlPwYJobTAhRgfLUgqperT2gPXYHwcgaRUiOl1xpgxY/jjCPv9gOuxEq4Ke0EAa7FyUV61apXT7Qq+A6csvw+WGhWf7ltw83lDCoIgCDmw3fvz8zPAqLuxWkaSTAkeRCy4giDooiAIM/ddlCXJlJA/SUpK4oR/KOcHbx/kboDHjiAIxhELrot2ERdlwYOIwBUEQRcFIXbUmgBK//xiwRUKAo8//jhn39+xYwfnS0BeBUEQjFMQYkfdSaTobhbl/D7oLriPCFxBEHRREGJH3bXgGnVrlmey4C8UKlSIbr/9dlviQ9Q9tw+PEQRBHwUhdjQvsigXhIEC4caQGFxBEPzKRfn48VgqVy6cChUKNk2ZIGO1c2XUWfBfkPkeVlx7xo0bxx9FbGwsLV682CMu0p5YT0FA2sr8bZV6+TL//9+//1Kh6GjyFenXr1NGUhKFlCzp8Xa6tHs3JxY1stzlS5co+dAhitO5TGpmXhe0Y+EzZ8gMyPVnrnYSgSsIgl9ZHocMWUAjRrSmu+9u6MdJptzZO0HwLcjIj/jb5cuX55g2cuRI/igqVarE5ehuFLwIeWI9BQFpK/O3VfyZM7Q/s4xj6caNyVds+fxzOrtpE/XMpUKFO+209dAh2rlmjaHlZo4eTVVq1qR2OpeJi462tWOZpk3JDMj1Z652EoErCIJfWXBTUtIpNTXDr5NM5XdXbyH/8emnn9K8efO4fnqRIkV8vTuC4JeYxbU2PSWF0lNTvbNyN12UpUyQ4EkkBldwCWKtxo8f75FWQp3ds2fPOp3+9ttvs+tCXrJ9+3aaNWtWnm7TXzGL5TE93XsC0egxulPxwSwDBYKgF7gez5w5k5YuXUrFihWThhMENzFLciRLerrX4oCNJoyyLmTsuWiWgQLBvIjAFUwjcN955x23BG5aWprb+yQC1/+EmTf3Q8oECUJ2oqOj6fnnn+eY2i5dulCzZs3opptukmYSBDcwizBzJxGUN9fttgXXBO8kgjkRgevHrFu3jtq3b8+1CZs0aUK//fYb/75582aOS8Bvbdq0of/++88mVjH6/tZbb1HLli2pVq1atHDhQp6WmJhI9957LzVo0IDX16NHD/79iSee4PIQeKnp3bs3//bCCy9Q69at+beOHTvydAUybSJOC9utXr06TZkyhX9/99136cyZM7wNLAdhqeW5557j/zt06MDTz58/TzNmzOAXqebNm/M+/fHHH7b5O3fuTE8//TTdcsstvK+pqak0fPhwrtWILJ94IcM8ip9++onX1aJFC95nlLvANt58801auXIlbxPHKpjfguvN/XA3yZTxLMomaEhB0AFiadFfjxw5wvdtfDZs2CBtJwhuYBZh5m2B61aZIMmiLHgQicF1k4YNHSe4gciEcEQijrvuuosCA3OOIezZs8cWaK1NymE/3RWXL1+mvn370pw5c1gUZmRk8Ah7SkoK9e/fnyZNmsRB3P/++y8NGDCA9wdcvXqVhS+spYsWLaJnnnmGS0DgO5bfu3evbf0A1ttnn302myB9+eWXOR4LwL0X68DyirCwMNq4cSPt37+fhfBDDz3EQvKHH36gX375hcWkPZ999hmL4X/++cfmAof9v++++1g0Q5xDuJ44cYLXDw4ePEhr1qyhkJAQ+uabb+jQoUO2tsMxKSDw4V6HebEstnH//ffzvBDeCxYs4I/gH7Gj3rbgejvJlNFau4IgCEL+wCxlgtxyIzawbo7DNbqMG/FBvh4oEMyLCFw/tt7WrVuXxS2AkC5RogTt2rWLv6sMZbDwli1blgUqRuJR0xACGMD6iVF5AAvpvn372AraqVOnbALRHsRhffXVVxQXF8fCWolhxQMPPMD/16tXj4KDg9ktGds2yrFjx3hdcJHDerAd/Ib1ggcffJDFLUBWT+3fDz/8ME2ePNk26ACLrdatDuuC1VrwbvF2/7Tgej/JlBnaURAEQchj3EncUFAsuBKDK3gQEbhukpuVFVbc9evXU1RUlNN5IEL1WGtvFFhAFbBgqr+DgoIoPT2dv9eoUYOttytWrOAsmS+99FION2Jw8uRJ+r//+z/atGkT1axZk3bu3Mkuv1ogohXYhrsxsoMGDaKPPvqIBg4cyH9DwGtjdMPDw3UdM26aELxwnRb830U5PT3DNEmmpEyQIAiC4Hcuyl5OMpVXMbimeCkRTInE4PopiLGFSy7cbYGypMKqi++wsoK1a9eyBdWRW7AWWEkhChFnC/dj3HxPnTpFkZGR7NaswHdYScuXL8/zfP3117r32X5d9kRERGSbfuXKFY7jBdOnT+e/ndG1a1eO2UUsLj7Tpk2zTcMxYXmIc4D2QZyynn0SzGd5zB9JpnzfjoIgCELeYhZh5m0X5byy4MqzVHCGCFw/pXjx4jR//nx65ZVXOKYWyZMQaxoaGsq1CpFICr8jfhZxuq6snQCuze3atWNXZSR1QtwslscH8caNGjViodi4cWO2rOI3xNdWqVJF9z4jKdRjjz3mMMkUQGKo7t2725JMffHFF2y9xf5s27bN5baGDRtG1apV4yRZOA5Yl1UsL9y4P/nkE+rXrx8fH/ZdlQa69dZbKTk5mY9Tkkz5hwXXjEmmjC5jhlhmQRAEoeAK3HyRRdnHscyCeREXZT8GSZdUhmQtrVq1YsutPRCASCSlgOhVo1+33XYbf+xB7Ouff/6Z7TcIT3wUr7/+uu27/WjaxYsXbd+HDh3KH2dAlOOjQEwtPoqxY8favq9atSrbsrAqw/IMKzAsuIjdRYyxAqIcH3vgQu6orQTzWh7NaME1nkXZrd0TBEEQ/BizWB5NacGVLMqCBxGBK+QbunXrxtZYxOkiuRYsxoLnMIvl0Zv74X4WZXFRFgRBEPzD8mhUUHp93eKiLHgYEbhCvkFqM3oXs1ge09ON7Udycho988wi+vbbOygwMCv5mK9clDGvGdpREARBKKAuykgwanAfNnz8MdW86y4q1aCB6xnzwEXZLNmoBfMiMbiCIORrF+XLlxNpwoQtlJqa7vF1iwVXEARB8EcXZaPi8NC8eXRx1y6vuSi7FYNrgncSwZyIwNWBKjkjF1LBQp1vbcmhgoxZLLhG9wMWX6BnGSkTJAiCIOR7C647IlSn1dfdJFNSB1fINy7KKHOD+qRIRIRkP1OnTuUMt44y/D711FN07tw5/vv999+n/v37c7mXF154gRYtWsTJkEqWLEmTJk3iGrQAyZEwHbVekf0X60dZGKMEBgZyEqNLly7xNvQKHuyfqjMr+Fdb4UaL843zjvMv+K8F10giKLHgCoIgCF7DJJZHt0WojtjaPM2ibIJ3EsGc+FTgorTL448/TkOGDOFSNvh/06ZN2eZJSEigPn36cF1TJA6CCEK9V/D7779zFuEdO3awEBk9ejSNGjWKfv31V4qPj6dHH32UVq9eTfXq1aP/+7//o/fee4/GjBnj1r6iRA3qqKpt6yExMZEKFy7s1vYKGmZsK/QpI2WQ8jtmsuAaSQSVnp5hSOAaWbd6uEoWZUEQBMGvLLgGE0HBgqtX4Bpet8UiWZSF/CFwUed08+bNtGTJEv57wIABLEIPHz5ss8CCGTNmcDkciFsQFBREpUuX5u+wpKqsubDgXrt2jSpVqsTT/v77b66fCnELhg8fTj169HBb4KK+LPYLlka9I0bLli3jzL6C/7UV+pZYbh0lR/K9woVgdS8RlF4Lrjvr9r9s1IIgCELeop5Dvn6Wslj1khuxWyWI3M2iLHVwBbMJ3FOnTlH58uVZmCpBoaykWoG7d+9eCgsLozvvvJOio6OpSZMmXA8VIveuu+6ilStXUrly5bj+acWKFdliC7CeqlWrZqsBGxMTQ2lpabZtgnHjxvFHgTqxixcv9sgxQnhDuAnSVp4CfcpT/dMoR4+eoNTUNJ9tX5GcnEL79u2jxYuzajq7aqvTpxP576VLl1HRoq5vedevJ/C9Q+8xHjgQz//D8yQ9/ZCuZY4ePc73IV+3oxn6lL8hbSUIwo1gE2QmKBOUH1yUfW0JF8yL6csE4UUQInH9+vVUoUIFdkF+8skn2aUZFuDdu3fT6dOnObb2lVdeoSeeeIKmT5+ue/0jR47kjwIW4J49e3pk3/HS6Kl15XekrczfTth2YOAln/fpoKDtVLduPerZ82ZdbbV//0Ui2kFdunSl4sVdu8GHhe2lSpUq6z7GYsWiiWg3tWzZinr0qKlrGeQMMEM7KuTak7YSBCFvMEvsqLtJpnS7KHs5yZQStr5uR8G8+Cx7TuXKlW0WVdVJYTmxj3nE3126dGHrLKy8Dz74IItdgLjcrl27UrFixdidFAmrYNFVy504ccK2nuPHj2ezGAuC4L9JpozGvAI9u27UDVvKBAmCIAj+Znnk/TAaJ6vXyupGsXex4Ar5RuCWKVOGWrRoYbO2zp07l62nWvdkcM8997D7H+JrwcKFC6lp06b8vUaNGrRixQpKSUmxZU1u1KgRf+/Vqxdt3bqV9u/fz39/++23NGjQoDw9RkHIT5gpyZQREerNJFPuxuCaoR0FQRCEPMaPLbgZ3kwyJVmUBQ/jU3PmhAkTOHPyBx98wC7GU6ZM4d+HDh1KvXv35g8ssXBLbtu2LVtpYcmdOHEizzdixAiOxYPgRcZbxOKOHz+epyEmd/LkydS3b1+2EkP4/vjjj748XEHwa8xiwUVdW3cSQekvE+SddZutHQVBEIQCasHVWdM2L2NwjYhis7SjYF58KnDr1q1L69aty/E7hKmWhx56iD/2IPkU6t46Q4lkQRBuHP+14BrNopwXLsq6ZxcEQRDyCf4eg6vn4ZUXMbhmaUfBvPjMRVkQBP/CLJZHb1pZpUyQIAiC4C3MYnnML1mUpUyQ4AwRuIIg+FX9VnfjZL0rcMVFWRAEQfAPYeZunKxZsiibZaBAMC8icAVBKBBJpvQskhdJptxIMCkIgiDkA/y+TJBeF2UvJ5myzSsPU8EJInAFQfAbF2Vs3/suylImSBAEQfA8/p5kirzkooz1Sgyu4ElE4AqC4DeWx6xBW+NJpsyVRVn/NgRBEIR8gkksj25bcPVYZt11UZYsyoIHEYErCILfWHDdrTtrXcabFlzj+yMIgiAULMzkouxWkimdLsp5lmRKRosFJ4jAFQTBbyyP7lhMVQyumZJMGV1GEARB8H9M46LsRpxshk4LrrtJptwRuL5uR8G8+LQOriAI/oNWmAUEBPh8H4wvo29eI+LZHW8z7f74qBkFP+bLL7/MdZ6iRYvSo48+mif7IwgC+Z3l0ZtWVr2xutmWsRjznjJLOwrmRQSuIAh+I8yMZEQ2c5Ip9X9goChcwRjvvPMO9e7d2+U8a9asEYErCCbENGWCdGZEzoaXygTxvEaTfJikHQXzIgJXEAQ3xJz/WHDzIsmUe9UNZORZME7Tpk1pypQpLufp2rWrNK0gmBCzuNa6Y8E14qLszkPRsCjWLCsI9kgMriAIXhNznsbdrMXeTjLl7dq5gqBYsWKFR+YRBCHvMYtrrTdr1Rq24LphjTVLOwrmRQSuIAh+kxzJHXGoN8mUOi5JMiUIgiDkdwuut8oE5UXCKLO0o2BeROAKguA3lscbjXn11rq97dYsCM5YuXIlNWrUiGrUqEFTp06VhhIEE2MWy6NhEaoGgL0Rg+tGm4jAFXJDBK4gCH5jwVXxtN4QlN52f76RZQRBcfXq1WyN8e2339KGDRto165dNGbMGGkoQTAxZhFmRpNMGRGhRt2fb8SCK89RwRkicAVB0IU7AtCfkkzllTVWLLjCjYAMynPmzLH9HRoaSlu3buVPSEiINK4gmBmTZP81bMFNT89aztPrdkesmmSgQDAvInAFQdCFOzGqnuZGrKzedVEWC66QNyxZsoS2b99Od999N505c4Y++OADmjRpEn3xxRf8vyAI5sUs2X/dtbLqWsad5FX8RSy4gueQMkGCIBSIJFO57feNWGONCG61H760hAv+S1hYGI0ePZpdkh9++GHq168fTZs2zWvbe/rpp+n333+nEydO0LZt26hZs2Ze25Yg5HfM4lpr1MqKEkHWBfW5KFtntVBAQIB3sigbiAkWCiZiwRUEwW9cayXJlFDQycjIoIULF9K5c+do0aJFlJqaSr169aL9+/d7ZXsDBw6kf//9l6pWreqV9QtCQcJvsygbEKFGj1GyKAveQCy4giD4jQU3yxprZBljLsqSZEowM/fccw9FRUVRQkICzZs3j5NM9e3bl5599lm2rr711lse3V7Hjh09uj5BKMiYxoILi6wbFlwjAhf/BwQGejWLsq/bUTAvInAFQSgQFtzcFnEnNEqSTAl5zeHDhzkGFyh3YVhX58+fTzNnzpQTIggmxl8tuEb2Oytfh1hwBd8hAlcQBL+x4EqSKaGgU716dRo6dChbcNu0aZNt2n333eez/Ro3bhx/FLGxsbR48eIbXm9SUpJH1lMQkLYyf1td3LOH/9+1cydF+7Bfx127RhnJybm2gWqntMzyZEePHKHEXJa5fOkS/79k8WIK1JHZPfXyZf7//Pnzus+JrR137aLTJrk/yPVnrnYSgSsIgh+WCTJHkil3MkubwRIu+C+zZ8/mlwOUBOrevTuZhZEjR/JHUalSJerZs+cNrxfH6on1FASkrczfVlv27aMYImrYsCE19mG/Pl2kCKUFBOTaBqqdrp87R/uIqFq1atQ5l2VmvvceJRDx/Sk4LCzXfYmPiSFkEChdqpTuc6LasZGP21GLXH/maidJMiUIgt8IM7MmmTKWRVn9LwpXMM6yZcvojjvuoB49ejjNUIrkU4IgmA9/d1H2ZpIpd7Io+7odBfMiAlcQBL9xUVYJo/JHkindiwiCjZdffpni4uLo2rVrTj+vvvqqx1ps2LBhbI2Njo7mUfdatWrJ2RAEfxe4BpNM8fzAYJIpXeuWJFNCfhO4hw4dorZt21KdOnWodevWtCfTp94e+Nh37tyZ6tevzx9kjgRTpkzhJBvqU6pUKerfvz9PO378OAUFBWWbfuTIkTw9PkHIT5hBmN2YCPXMfJ5aRurgCu6A52GxYsVcflBCyFNMmDCBxW1aWhqvF0muBEFwD7Nk/2ULrhGLqYH9NnqMN1ImSOrgCqaMwcXI8OOPP05DhgyhOXPm8P+bNm3KNg8SafTp04cL2bdv357S09PpcmZA+iOPPMIfRaNGjeiBBx6w/R0REWHLNikIgv9bcM3qouztZQQhq//ofykVBMFcmMaCi/0wmYuyO/vj63YUzIvPLLjIlrZ582Z68MEH+e8BAwbQqVOncowOz5gxg26++WYWtwBW2dKlS+dY34YNG3idvXv3zqMjEISChRlCXm4kyZR+gevd/TGDJVwQBEHwAQZL6JgmBteNOri6H3LuWLVNYgkXzIvPLLgQs+XLl6fgYOsuIFlGlSpV6OTJk9lifPbu3UthYWF05513sptUkyZNaOzYsTlE7vfff08PPfQQZ5ZUXL9+nV2fYfXt27cvvfbaayyQ86K0AZCU4dJWnsaXferKlVj+f8WKFVS8eKhP9uHgwXj+H/cJveUN9u07w3/DOyQ9/ZDT+c+eTeL/L126pLuN1br37NlLixdbPUv0t+NKKlnSN+2oRe5T0laCIOQN/m7BJZO5KPu6HQXzYvoyQYj7QdbI9evXU4UKFWjUqFH05JNPskuzVsjOmjWL51FAPJ8+fZrKlCnDLs333nsvC+OXXnopT0obAEkZLm3laXzZpyIiTuBqo06dOlP58hE+2YdixaKJaDdVqlRZd3mDbdv+hSSmFi1aUs+ezhPkHD16hYi2U7FixXW38fbt1nXXq1ePeva8yVA7Iq9AhQq+aUctcp+SthIEIW8wS+woLLKGQmvcsOAaTjLlpZhgoWDiMxflypUrU0xMDAtY1UlhlYEVVwv+7tKlC1WsWJGtvHBp1gpZVRcQNcUaNGhg+w1WX4hbUKJECfrf//5H//zzT54cmyDkR/w9yZRZXJSzaufKg1kQBKEg4fdJprxZJsiIBdcMMVOCqfGZwIX4bNGiBU2fPp3/njt3LltP7UsQ3HPPPexaiNIHYOHChdS0adMc7smPPvpott8Qj5uamsrfk5OTOfNy8+bNvXxUgpB/MUNyJHf2QcXg6s+iLGWCBP9JOHXmzBkeHFYfQRDMi9+6KKsyQSZzUfb1QIFgXnzqoozyA8ic/MEHH1BkZCSX/QFDhw7lZFH4wIILt2SUEwoMDGRL7sSJE23rOHDgAGdKhvDV8u+//9Kbb77JMbewEnft2pVjcAVB8H8LrjfK8kiZIMGfmDp1Kj399NOcdwLPRgAvJwzuCoJgTswizLAfuF8YmV/7v0vywoKrtiFZ5QUzCty6devSunXrcvw+efLkbH8jeRQ+ztaBovf2oB6uqokrCELBteBKmSAhP/Lee++xdxOegYIg+AemsuBmDozpnt9oDK4XLbiSRVkwrYuyIAj+hRksuOnp7pQJ0ieKvWkdvtHtCII9pUqVEnErCH6GaQQuXI7dKRNkwEXZsAXXjZhgX7ejYF5E4AqC4DUx549JprwtVs1gCRf8H5S++/zzz9klGTkq1EcQBPNimizKeZBkymgWZYnBFQpUmSBBEMyBGYSZO4JSJZnSH4NrJJOj+l8suELeonJKaMvcIaYOdd8FQTAnZorBNfSsU/cVL2RRVvO5FYMrA8WCE0TgCoLgN661N5bp2DPz3egy7ohiQcjZ93xrARIEwTh+m0XZgDDPkyzKUm5PyAVxURYEwW8eKHmTRVnKBAn+A8oE4SMIgh9ggueoWxZcs9XBNclAgWBeROAKguA3Fly97sZ5nWRKYnCFvGbfvn3UsGFD26dx48a0f/9+ORGCYGLMIszgcmwkBjfDZHVwJYuykBsicL0IXqx9PUonCPkzBtdcSaa8vYwg2DN8+HCOw71y5Qp/8P3JJ5/Mdw2Faz0jLc3XuyEI+S4G1y1B6cUkU95KeiUUTETgepGPPjpEs2btznU+3OjS0uQiFcyNGSy4Zksy5c2YYEFwBUTt/fffb/t70KBB/Ft+4+qqVfTXAw/omleEsGB2zGDBtT2vjDy3VJkgcVEW/AQRuF4kNjaVzp+/nut8a9eeonbtfvDmrgjCDWMGy2N+SDJlBku44P8EBQXR3r17bX/jO37Lb6TFxlLC+fO65h1fqRLFRUd7fZ8EwV3MYHm8kZhXXcvkRZIpEwwUCOZGBK4XSU21UGJi7q5VZ87E8cdTXLyYQDVrfilWYcGjmEGYuWfB1SfM3UmiJRZcwVd88MEH1LFjR+ratSt16dKFOnXqRB9++GG+OyEZKSmUlpiY63zpKSmUcO4cXT93zmPbnnvHHXRq9WqPrU8QyAwWXHcEpZEyQUYtxFIHV/ACInC9SHJyBiUmpuY6X1xcCsXFJXtsuydPXqWjR6/QkiVHPLZOQTCDa61esXpjWZT174+jZbZsOUOrVh03dTZqX3DkyGWX7SIYo2fPnpxoCnVwn3/+ef7eo0ePfNeMFp0CNyU+3vp/nOcGi48tXEhLhw3z2PoEwQwxuEqseivm1d0kU9r5U65fp+3jx7tYyLibdX4AYRi7f/zR17vhF4jA9SIpKRm6LLgQtxC5nrrhJSVZtzljxi6PrE/IezAwos6jWTCXBdfzVtYbSRilXfevv+6hiRO36FiGvA7ij1NTM0fefQzuR2PGrPX1bvg9169bw16uXbtGYWFhbMXFJzQ0lH8rqBZcJWxTPShwweUDB7IyyAp+Be7LSbGxZCbM4FrrbRdl2zEaTDKlbZOLO3fSqpEjPbI/niAt2XNGqBvh0r59tGjIEPZYEbwkcFNTc7dMFnRSU/VbcPHSm5DgmTa9ft3a8WNirCPagv/x6qvL6aOP/iUzYQYLrjddlD2VoTk+PoXDBDy5HXf5+uuN9H//t5DMQHT0NYqNTfL1bvg9HTp04P+LFStGxYsXt33U3wXWgpspbJO9IPLTEpxfz4J5gXv5L507k5kwhQX3BlyUvWrB1awbHhm47lOdXHt5OVAQe+wYTapWjcyAyjGQfPWqr3cl/wrcjz/+mP8fOHAgvfTSS/Tjjz/Spk2bbKPLAiy4+mJw8UKshK4nUELZU4JZyHtOnbrmNEFZz57Tad++C3m+T/5uwc0rF+Xr11PpwgU9Ajfrt2nTdtDevZ4/pydOXKUzZxwPdMGyW67cp5wMLy+Ijo6jK1dyFyqCa7Zu3cr/nzt3jtLT022fjIwMOnv2bIEVuKkedlHW3mOcvWQL5ibu1CmnCcouzJ1LWz7/PM/3ye8tuHmURTk1U0skXLige5mYjRvp4Ny55I1+dP3sWadZ2pHlfc9PP1FeEJ8pcJPyYcZ80wjc119/nf+fPXs2DRs2jEqUKEHLly+nESNGeHL//N5FWY+bqYq/9VQcLl6wgQhc7wCBsnHjaZfz4KZ79apza1VychrVrv2V03N+4cJ1pwMe69dH0/79F6kgW3CNuBGrMkH6syjfmIuyXguu9hgefngBNWz4rcfdiS9dSqRr1xz3sStXkujcuet05ozjfvrmmyvp7bdXeWxfTp8WC66nY3D1/ObvZKSmUlpS7pZ/JWw9JXC1oloErnc4u3lzrqWdcrNU/T1kCB3+7TeH0xIvXHDaH5KOHaNz27ZRXuOvFlybm34eZVFWA1aJFy/qFtzbvvmGfh84kE6u8txzCyRdusT/O+tLV48do4u7HZcEPbtlC01r3txj+xJ32vrumWwy1/t8IXBLly5Nt912G7355pv0+++/84hxzZo16a677qJXXnmFpk6d6p099VsXZT0C17MWXLgoh4QEisD1Etu2xVCPHq5H6zZtOkNt2kx2Oh0C6PDhyywwnE13JExQLxm/O1vOm6hnjy/LBOkVq7634F53+nB3JIqLFy/E/+spK2aES5cc9yNw+bL1Bf78ecfTjxy5QsePx3rURRmiWrgxUlJSONYWVtu4uDj+js8pWBnyoQeVsuDm9rLsaYGrLEiBISHiouwlfuvXj6L/dR2K80P9+hx36IyLe/bQlUOHHE6DOIJQcmR1TL92jbNu5zkqyaAvywRpYsp1C20fWXAxSKF3G8GFrM/RS3v2kCdJzBS4zsIfki5fpmsnTjicdvXoURbAnkIsuF4UuAcOHKDnnnuOChUqRFOmTKE2bdpQpUqVqG/fvjR69Gijq8u34CXWWiZIXwyuJy24sNyWLl1UBK6XUOLT1YMht9JP6kVfiQxH23DUH+LjrQ+mc+fyPr7akTBDDee89BTICxdl+/lcLefMgpucnG4LPXC+TNZvmB+cPRufhxZc1wIXIt1Z/zQKPFmwL/jfbMnT/A2UAkK87e7duykqKoq/49O4cWN68MEHKT8mmcLLLCy5eZlkiq22AQFUqEQJseB6CQjQFBcWWpx3uIbGnznjdJ7kK1dYYDhbvzbDtpb0uDifCFxHwuzqiRN0+eDBvN8Hu/3Qs4yhGFzNvK6Wc9Qm6pwZcVFWVl/0GW8I3BRnAvfKFacCF/sPL4TcPBX0IhZcLwpcuCKjFMGoUaNo/vz5PGq8efNmGjp0qCSe0qBe4ozE4Dp7EXXG9u1nHbo0woJUunQREbheAi/quKcqV3Bn4gHnNSUl3aW4cCQgIICcCZNr19I8bunDA+KZZ/7OdTDGkTBr1+4Hdq/1hyRTerMoa+eDlT0o6F367LN1uisVqCRvztyUs5ax2KzSGCSAFdfTlnl9FlzHQhz7j35ohHHj1jns03BPDgoK4O+uXPeF3Hnrrbc43vbxxx/n/9UnNjaW3njjjXxpwQW5xeGql1ujSaYgntRLY7b1Xb9OIUWL8keSTHkeDCDA9dyVxZ3dk5EJ2YmAVeLC2XQljhwJkzRYcJ3E57rLzsmTKWbDBpfzOBJmfw4aRD/UrevRfdGzD/b74SkXZUfH+F2FCjS1SRPH23NQOs9mwXXiouzo4Yu+VKh4cY8PXNhclB30I87UffkyxZ086XBZtf9GYmaPL13qtP42LLgBQUHiopxXZYLKlStHd955J73zzjueWF0+E7ipBmJw9bso42W8a9cfaeHCnK45eMEuVaqI7UVb8CzqBd7VgISy0DpLquPKgotlcH4d9Ye4OGu/8qQQgoj58suNnJDIHevpnDl788xtOa+TTKGmNPjllz2GsigDZ4mm7LejBkpq1izhlgUXbXHiRKxhC25uLsrYf6MW3LfeWkUbNkQ73FbJkkWocOFgcVP2EN999x0VBGDB1SNw3XVR/ue11+jfzJwiOQRukSL8US/bgudQotTVgIQSBc4ELIQUYhETc7PgOugT6fHxLHA96Sq8Z+pUOrlypct5HFkrI6tWtSVJyk8WXO26ITov7trlUHw6Kitki8E14KIMq29UzZpuW3CvnTzp8PhcuShjP2GdjY+Jcehlovbf1SCNPXunTaN9M2Y4nIb1RFSuLEmmdCB1cE1gwYWQgXXD3iUViYwGD57vcBlYliCSdu8+78SCW5RjgM1SAzM/oV76XbmUu7LQ5jZdWf4crf/atVSPC1xY11ztqzNhphWZnozVdEesrl59nFatOu4ybtedMkFok4AAazyq3mWUYHVmwbVfRgnimjWLuyVw162LpqZNx+cQ/Thu9DN4ESCpmT24fxQqFExnz+bsZ1gX9t+IwMWAGo7FkWs+2qRo0RAqVqyQlAryEOfPn6cnn3yS2rZtSy1atLB98qsFN1WHwIVlw17M4IV1Rrt2Tl8IYXFzlCBGWXCDIXAli7LHUS/8rgYkchO4WBbnN1cXZQd9Ai7KECaezEYLT4DchIwjYaZ+O51LPLKncOY6nHDxIm379tsbKhOkfQ7ZvJSU8AsIoNgjR5zujxELrjMX5eK1arklcLGe6a1b06k1awxZcLn/BARQYHAwpTrwCLBZcA0I3Ovnzjl1y0e7RFSqJBZcHYjA9bLA1ZtFuVy58BwWO2TKXb7ccXC6spLs2nXeSQxuEd0CWzDu9qnXgutc4DqfroSRo/XDgovBEE+6KJ8+Hed0X2AZ/PTTtQ6FmerbZcsWpT17nLt6wQpas+aXTq2ucHGePn2nQXfj7L+/8spy+uKLDTfk1uxoPpzrNm0q8jlxVMPV0TIQebiekVRJz3YwP4RmpUqRLgUu9uHOO3OO6q5bd4quXk3O0V+wv2objvoSznfbtpUpOtoaG2t/D8FvmEevtVwNujgWuCkUHh5KxYsX9qjA/eKL9VzrtyDy6KOPUrVq1ejixYvsPVWhQgW64447KL8K3PRcMilDxBQtVy5HDC6sOmfWrqUrhw87dIG9vH8/J6WxuWBmArdkdlEuUkRclL1AbnGNfH4yxaczC21uAtgmcO22wZa4jAweEPGUmzLuk9fPnHG6L2teeYVSrl93KMwQh1ykbFlOmOWKmR060Jn16x1OOzBnDv1x7703lGRq1/ff08pnn6X0zGsu2zI6MyM7sg6rNinXurXD69CZNRbXs6r7qneZYjoE7qJHH83R1kgGhb7gKJbWVV/FscEtumSDBpyZ21kfVOvQA/YffSmvBO6lfftofp8+lN8QgWsCF2W84FaoEJHDYoeX0piYOIdW2M2bz7DFx5kFFy7KZisVhBvjypWeyybnKy5fTvKAwHVuwY2JiacyZYryebS3OkLgwpXVk0mmlAVXCXctsIp++OG/fO7sracQVeCWWyrTnj3Oa7hu3RpDR49ecdoW//130qVA1hMni9JJyG7tShS7k2QK+4z2LlGiMB05cjnX/eGXnOsp1LJleTpw4KKu7eC6j4gIZVHsSuDu2HGW/vrrUA4xumHD6WwDFVr35LCwIAoODnQqcJs3L0dFigTluI8o92pk7dYbOqH2Hf3XsQU3lC24nqyFu3ZtNG3Z4vi853eQ/+Lll1+msLAwrmIwb948WrZsGeU3lNufnhjc8AoVcljr1Espalnac27rVl4GL/z2mU7xIgnrrRktuBA5Ztsnty24N+Ci7Gp6WnIyi4oiZcrk6BNskQsKYldPWMs8AYQMhKEjIYOBlI0ff0znt2516OqL6RXbtnWZ/Rfrjlm/3uk8mHZh584bclHeN306X2+X9u51Lopzs+A6sA7j/OA6KtWoEcW6ELj2FtyyLVvS5QMHXG5Huz0MbhWvXZvdoJ0Jcfx+4Ndfc3htqNjpeAfx+DinIeHhDl2UlcAt26IFJTo4NhUHbsiCi8RqMTEO+wC8DsIrVvSo58H57dsp2oHl2t8RgetjF2VcbHiBhMC1fwm1Zup1bBE5cyaeevWqRQcOXOKXUC14wcaLpNlKBWFfb711Wo799V8XZecv/uol3llZFOX66kj0LV58mG6/vTZ/t8/EC4ELUQJx6arWqucsuFf5d63FWD03kCwIlkfsjyuBu3evdZojiyYGgI4di6Xo6Din1wcGeVxZTP/66yC1bl2B99WRSHcWt2s/+OTMRblkycJUq1YJFtLO152VDRmCulWrCrR//yXdLsqwbkLgunI9V27S9udJCVz7+wQGQRCqEBkZ5lDgom9CuNeqVZQHIbSgb2GQLDAwQLebshK4ju5XOEa4KCORltHEVa5Anzp16irdcccMj4djqPsUBk98WbPSGaGhofw/KhpcunSJgoOD2ZpbUJNMQcRArNq/hCa7ELhwA4yqXp1K1KuXQziYOcnUoiFD6NiiRVRQXJSVJdfhOgICHIqHE8uWUWSVKlSifv0c24BFODgigs/9VQcus+6ghJGjfVFWQVjKHFkeIXDL33ILC0tn9xpYPiFunFk0sW5n03j/YmKyBmIdJJlCJmeso0zz5jzwo9eCC/djmwuyCwtu4ZIl2X3YlcC1r4NbtlUrHnhyVAfboSU804ILIejMwgnBiXXbD0TYBK6d5RTrh2AuVrOmUxdlZFpHuyU66EsY+IAlWq/AxTnGMtimfeZllVkaFlwjFuHcQL9Be60cOdKph4C7qGNA/73u4aRuuSEC18cWXAhgvEhVrRqVQwypbKOOhAFe5Js1K8cXn7LAKSBq8TJZpEiIqQSu1d3ReeKl/Oai7EzAqukVK0bmmI6+MH/+fnrkkWYOt4EsyjVqFKdq1YqxRc/bMbgqyZISsDgm9UDBvkVFhVGDBqVdWmBdCdyDBy+x4LPvw4oZM3ZR3bpf24S+IxG6cuVxGjiwAV9DyCyuxzILN9mqVT+nBQv25+KinMgiEN4SjuJw7fdHJXaDBXffvgu5xCdRDoHryoKrLMja84T5IfBatCifow1xznBunAlcrAfHVqNGUdq581yOEkEIc8B0R4MGjoCgRv9w5qIMCy72Z9cuz2W4RJ+CBRfJ9jwpnHHu6tX7ms9vhw5TXA7g+Io6deqwsEVpoJtuuolatWpFLVu2pIKaZAoiAcl67MWQKkPj6OUfljy8eEfVqEFXj2eP4U/VuCibzVoKgabiAvOzi7KKb3TlohxRsSILWK3IAgfnzKE6AwdSWFRUjkEPtF1QZCSVadqUrVeeIM6VwM3MsHtZCdyAgOzC7No1dt/FoIqjgRigrKpOBe7evSzcHFkZEVs7qXp1Ovrnn05F6KmVK6k8yn527Ejnt23TnWRq4YMP0pLHH88xn3XVFtu5hghEAigjMbiwxuIavOKghJK9KMayOH6ISSzjzE1ZDWjYnycIXAhqewsuhCb6GdrGqYsyBG6zZjlclLFPEKvF69bVLUjZ4mux8PHZu8+ruGTsJxJ2eWrgNT6zT+2eMsVj14NiauPG7FkAF/2dEydSgRG4hw4d4gQZeFC3bt2a9jhxvdi1axd17tyZ6tevzx+4YgHU4W3WrJntU6pUKerfv79tuT///JPq1atHtWvX5t+vGSwfcCNA2CJWEgJW2wkhSpAQRwHrFCytdeqUzGGRUy+lp07l3G/Mi9jHypWjciT4gTsgxK3ZBG5uiZf8Bew/2ja3JFM4N64ELkST/TmHSMCLOmIjMUhhL0xgwYXowOCGIzE3c+YuCgh4h5Ys0T8qDesphKozCy5QAjYoKFBjwU1m8dSwYWnat++iLZmTI4GLa8GRwMVysBI6i1f97rvN3J9nz97jUKzi/9WrT1CXLtWoefPytG3bWV1JphC3CQv8Z59ljVZiOvbTqAUXy6h1Q6xC5GFfcF3aD3CpVeOY7S24uJ5dC9ycFlwkoqtfvzTVq1cqh7CEaG3cuAyfo1mzdueIfcV6YFEtUyY0R/urrMc49tyyayuw77iPuUoyhXhmZXG+UXBesS11XO7G9n755Qa6/fafs/2Gc402wXWMQSczDspNnz6dSpYsSc888wz9+OOP9O677/Jv+dGCiwQuWoGLhFMoyaLlekwMlWrcmIWuVuy4suDixb8QBG61anTNXuBmZlGGa6WZLLi4b0DEOxN9/oJyW3VZJggCFhljnRwrpkM08frsBARcUCvccguFRkTkECZYX1B4OJVu1szhCz3EyKcBAbT6pZcMiQSIaT0W3MCgoBwWXLhSw/roLA4XAhYxw44ELmJ7sY2AwECH05HdGa7H6ppx5EZ8atUqqtylC1siHQpcB0mmLuzaRUd+/532z5xpE5RqOvbViAUX82dzN46P53PH3hX7swaisxay8PHaEllluu/ClRjxzM4ErhLY2vOEZXHMtfv1y2HBhTgrVqMGFa1QgUv34BxqScx0UcbgWtrly9msrhgYS09OZqHurE6uPdhvCObCpUrl2BcOmyhcmF23sf9615kbqs/AiutubC88BHDN2PctnG8chxooKDACd9iwYVzL7+DBgxxLNGTIkBzzJCQkUJ8+fWj06NG0b98+Lm7foUMHnvbII4/Q9u3bbR+UK3rggQd4Wnx8PCfhWLBgAQtpJOB477338tSCGx4exC++yGas+PXXPTR5ctbNA/FqsNwg5jKnwE1xYcG1voDCkgcXT0fWEogwM5UKUhZqT1pafAFe/tHuuVlwYWl1Zv3CC3P37jU49nHZsqO23yEaIQQQNwlR0LDht9lcLyFwITqaNStL27fntISppGNz5+7NYf1DMiJHwPLXuHFZW2yxYtq0HbRixTFq1KiMTThqBSA8DKKiCrH4g9iw74cKxN/CwuioH2O/INYxzX40Etl///vvFA0f3oqt2lqxqmbFABH2o2nTctSiRbkcrrbOLLOILX7jjY60Zs0J2zmyitUsAa+14LoWuFnLqFjTihUjWLQeOnTZ4b7g/KplILQjIsL4PoA+5WhQCiJYWRG1fQrJ5iAasT37GFz0BQhcCN3x47dweIB9H8SxlSgRmkOUQiwizOGxx1rQM88s0hVWAIGLgRn8DwuwoyRTN91Ukfu8J+5LcJvX7pcegYv+gwGgLVuyXhxefXU5/f139pcu3Jfhbq7axVmogS+4njmKjwFb9WncuDF17NiRn5f50YIbVrx4tizKEC8rn3sup8Bt1CiH2FHiRlkpHFlwI6tVcxiDa7PgmqhMEPaFs//6uQUXL+gYWMitTBDEhbNjxfSiZctS+Ztuog0ffpjDcg/BGRgSQv++9hodWrAgm4BlC26zZnRhx44cVkklgnZPnZrtuYSBk/2//OLUgosBFnuBC3ffrV98wX2Tt5WebhVzmevFucQ5xb6WatjQaYwtkiAhztNRP8bgDPopBLKj6Shd1Gz4cDr299/s7qtNMqUeRBDWELfYBkS/fdI1R27EEHyVu3alcq1a0dGFC60/Zs4HEW9vwYWbb5KDwRlHol9dfyXr1+dEcPbwMsHBtmXUQAlEMay4jgQuhzxllmLSWlTP79jB26rcqVMOCy5EPM6rJS2NRfC0Zs0oVnOvwCALjg3bJDurqxKLzZ58kg7Nn09n1q2j3MB+Q6CjrbBtLdwm4eEUUrgwlW7SJNeay3rRDoroFbi/dutGy0aMsP2tMoBrB6wwgIj+jd9QLslZqEG+E7gocbB582Z2rwIDBgzgpBmH7UZ3ZsyYQTfffDO1b9+e/w4KCqLSpUvnWN+GDRt4nb179+a///77b2revDlbcMHw4cNp5syZlLcCN5i/a604eHnVvtzhBb18+QiOd7MXuHhxx0smsinbX/34zrAAAG4TSURBVKR4yYXQgdCyt+Ca1UU5NwsujgMvqRA7OHYIHHfBiyzEi9GkVi++uMTmlgvsX9QhUPCyi3Z3FoOL84NjbdeuMm3ceMalGHjhhbY0ceIW2+9Wt99C2eZVyZys0yFwi9DNN1diTwB7UQiRAzfQrVuz39w//3w9DR9ufQDZl4zBMhBC9ucF2Y1xvEOHNufkRo4suLD8hoQEUd26pRy6KaPvYz7EyDqKs0U7YBo8HewFCqbBGnrPPQ25FI420ZU6bng3QBiGhga5sOBa2GKqteBCLHbuXI1q1y7BVlBXFtzcBW5Oa2xAQABbVe3dlNU+OFoG5xW/O0ogNnLkYv6/adOy2c7T7t0XeLCjbt2SfI60bso4HxicmDlzAE2efFeO/bdacAtTyZI5BS76OKy7I0a04evRvm/gHjZ8+F/Z2gqWXpzL1q0r2gYksua33pOQKRoDGk888Rd9//3WbELTFY4ShGG/0F5GBC6s/fZeMY7ukSruG4MzetedV6gB3mLFilHx4sVz/J+fYGtIejpbSLQWXFhU8bKntd7ghRVWlNDISH6x0lrHwooV42Q1OeLw8eKdacG1d1FWWZTNlmQq19I516/TlUOH+KUVguxGrCYQERAjW7/6ytByB2bP5qy+CpwPR22PgYXcYnAhXjm7rQMLPMQAhEX38eNp56RJOSz3oVFRtn6jrb+KbQdHRnLmW2BvxYXIKVG3LgtrrRUNiXj+HDSI+wqSWNkvAyEEAakdjNn06ad8PmAdRQwlRJLWuqkEPgRuyYYNnVpwcaxwY3ZkoeV2KF+eYzOVq3S26TExVKVrV74Ozm3Z4tCNGB4OHLNcrx5fd/aWVghetphqloUYhyiv0LatTWw5s+BCBOIYC5cundOKqyy4dvG0oeHhvD9w7XZq9c1cBhZf7F9woUJOBS4EPqzZNe64I9v1gwGz0k2bsqiEEDuS6cptO8ZGjaje/fdTj4kT2aNA6+2hkkwFhYZSUFRUtv6C/gvBjUGDiu3b5xCsYP0HH2SzUMMqG1m5MtXq148Ozp6dbV4l+gGmw+0XseY7dLr+WpwkCMOgCJ8vnQIX99uTy5fzx35QCPdbbb8DuMZxDXsy87MerArMB0DMli9fnhNjALwQVqlShU6ePEm1atWyzbd3717OEnnnnXdSdHQ0NWnShMaOHZtD5H7//ff00EMPUUhICP+N9VTNLJ4NUE4hJiaG0tLSbNsE48aN448iNjaWFi+2vkzeCBs3XqSiRa3jB3//vZSKFw+ls2eT6MCBM3TuXLJtGytWxFBQUAIdOLCdzp69lm3bJ06cpaZNi9KiRfto8eIw2+9JSahrmU47d66ntLSL9N9/0bR4cdbN9vLlONq5cyulpibQ2rWbKTjYHJmLN22y3phXrdpIL774Bz37bA2qVs2a7TkpKYkGDJhKxYqF0Pr1V6hBg3Bq3rwYDRhQ3vB2EhLS6eGHt1GzZpEsbFJSrAmbXIH6srt3x9Gnnx6kixejadCginTo0HV6/vndNHNmSypaNNhmQcXLdmDgNdq9G+crZxKx69fT2Gpfu3YcffJJDE2Z8htVqJAlWnFDjo6+SkeO7KDChVNo9eojtvO+eXMsBQWl8t/Tp7egwYO30p9/LqXy5QvZ9vPQoZ1Up044nT8fTxMmLKDq1a1tCHbuhMU1nObPj6G//vqbLYXg77/30JEjCfTKKz/TtGmnaMqU5vx7cnIGi5egoIu0ZMlxevPNmdSuXQmehuy6deoUpSpVLmuEfgYPJl2/vo82bIihpKQ43teSJdPpxx9XU6FC2V1m0OchQkqWvEYzZhyjW28NoNKls/ry9u1HqH59DPCE0vPPz6R7761om7Z/fxz3h9jYvXT1aiJNnfo7ZyYODIQV8zJvd82aSxQVhcRci9nj4eDBizR9+u+8DfQp/H4Z7mhBSHJ2kBYvTuBzCPEcE7OTKlcOpJ9/Xk2BgUdp504I9AxKTLQuB2JiYungwR1Urlwhtup16fI1vfRSLe5X4Nw56zLHj5/kZXbsuEoBAdbzFxWVQn/+uYGKFct64UhJURZotONGSkjYT9u2RdO1a0m0dOkSKlYsmBYsWE4NGkRka8dNmw5Tr16laNu2q7Ru3Q6qVMkqnA8ePE2NGmVQnTolKCIind55Zx5fMxD1EKn79m3mtkhPT+HBk4ULF9nENQbJdu/eROHhGSzo1DSwbdsJXsfq1cspJCSA/vhjKVWqVNi2P+j73323l9q3z2CBbO170dSpUyg1bhxEkyf/S1WrZomM/fuPUlRUCC1ZsoSeeqosPfLIdlqyZD+1alWMnn66hosr03pNTJhwnL75pgmFhmaNya5efZEqVy5Mx49bxcfq1RsoPv4Ae84sXWptn8WLL/A2wsICad26y1SlivUY/v13MxUubD1Ghfbeu2mT1ati4UKrC/u6dduobNmztj7lS7ZmJoDJyCWbqSeBF9TDDz/MSayioqJo6tSp1LBhQ69vV4kIvECqMkHIesulNywWFhOwZuBlFi+3cPOEa5+2diYsuIgrPLF0KVuCYBFSQMAUKVWKhZZDF2VYS0zmoqxeEiHS/nv7bX7hbfPii7bpe378kfbPmMFCCOIQL5mD3MyQuqBvXxZFiGdtPmIEt7ErcF85+tdfbLGE2Kw7cCD/9lPLltRpzBiqd8892YQBBB2sms7AeYQYgTjEy36rkSOzTYeYgNUR1ixYaiFGYJW1WXAjI6nnpEl8nrVWeHZRjoigoJAQqtqjB+8zRIgCIrFY7dr80o/Mx4jz1VqpDi9YwFmRByxaxHG8vC+nT1PNTAPLiqeeop6Z7sBoP/QjWPGwv4fmzmXRo4QZBAG2g/MIIYXjhICAYNKC89hw8GDaM20aDx6gbbXTwsuXZ8EOAVf/vvtY6GmnQwAjUzOsiNV69swSq5nXEQYAIHDRJhB7EE4Q+fYW02wCd+9eavTII3w869591zYf0LocK4ELCpcoQTPbtaP/7d/PglItoxXENnfcTAuuvdCzLYP+qCy48fHcztASzgRu7NGjVKlTJ2rwwAPZBm1w7GgfLNfhww9p0yefUM0777T1wTItWlCpBg34AzGpFccYAIIIByElSmQTuLBYwvuE+wFiwe0EHvrAlnHjrGWGMtcB8Y++V/fuu+m/11/nAavQTFELEa8E7s2vvcbX5ZJhw/j+1OSxx/jYnZESH09TGjaku2bNYtd9WzsnJLB7Mfoe4nqTYmN5gAbtC+GL0lFoA7hFo++gzdXAkDpuoDJ4az0y1DmA0FefAiFw9QJBitIH69evZzfjUaNGcXH7OZrRQbhszZo1i+cxysiRI/mjqFSpEvXs2fOG9zs6eiuFh1/gF+Gbb+7AWZLDwkZzxtmiRaMoNbU63XFHbVq1ajk1bZpEffp0oief3EldunRjSy46fmDgMXr00VtoyJDfqEmTtmzpBbAwBgRsov79b6fExF1sAdTuc1raNrr11g70xx/XKSioPHXv3tn2Qu4MuA1iu7BqeQvri2E0FSlSkfbvP0KJieWpZ8+b2dq6bNlSiolJp+vXg1mgbt8eR5Url7cdF9rD1cWrZdOm0xQXt4lOncpg65ue8/nGGyto9GirJXXnzjSaNKk7bdr0L6WkWCg5uQr179/Y5lIbErKV2rSpTxMn4v+ObAXTAksZ5hk8uDf99hsGNYrSI490s02HoExN3UD33nsb35tfffUjatasHZUtCxfVPVShQpxtn59+eh81bdqGrZMgLm4j3X474tFLU7duVygxsRz17Jl1s3rmmUM0ZEhnWrp0HoWG1qHu3WuyNfzYsQ0cKztlSgydP59M7dt3YVda6/FspmHDbqOvv/6ONmxIp3ff7cntnZa2iX79dTDVrl2S+vSJ44RMoaEh1KpVa+rUqRqtX7+KUlOv8r6WLt2EOnacwtvu3Tvrobh27SkqV+4IvfPOIDp8eB4tXZpBP/6YdT7effc0denSkp54ohTdfPNkGj36br5WQFLSfqpa9RLddddtdPPNZ2nbtlCqUaMmBQWdoWLFivN2d+1aS40bh9jaa9myDJo06TItWfIgX1v4PTIymkJCknngrGfPTvTvvyepQoUDNGDAHXThwmYaN24dffDBzRQdfYRCQ0/zMar1JSfj2urMFtJBg7bQqlWX6PHHO7FVGdbszz+/SKGhiVSlSmVeJiXlAJUpc5m/b91ahF2s8T8ynuMcWq2FG3kbyDuAdlyxYilFRKTyMlWrnqDq1RtRz55ZDw7w4otH6dZbb6Lk5ENsNe/Zs5utjbp3b8vX7YIF1vJgPXvempmgbgPddVcP9giwepFY+yvmQfx4RsYG6tOnB/377yr2KmvZsj33QfDLL79RlSpRfOwlSuyiJk1as2UWJZ1mz95L9epVx/AjVa3alNq1q8Ju9OfPb6D77uvBgwe9e8+kHj162K7ZadPmUaNGpalnzw7ct1588SCdP59A+/dbj/vQoUu8X/bXEhg//hc6dSqJNmwIo3ff7WK7ly1btoR69IikGTN2sxW8atW69PbbG2ncuJ60fv0Z9qLZsyeOgoOtA0C7dsVRYKD1e4UKNSk0tFxmmAEGIQplu098990s2HUoJKQMhhqpXLlq3Ba4h3ni+eAJkGAKMbh5GU6EMCI8e/H/pk2bvL5dJWrxcqwscd/BFVBjUYO4wQs8xC3cHFngXrjAVihYTCAg8Bte6uBSqRW4Ngtu9eo8HyyNELzqBRuughC4sKqwJRijaS7Ai+G+n3+mJkOHet+Ce+kSx00CCFy8kOIDaxResiG4Ds2bx8IBAwXBYWE2UaX3WQprX2BoKLc9RB8sSy7n37qV5t91l3UbgYEsKPACHXfyJAs7e4ELyzn28+LevSwe7IHVp0jp0tTgwQfZBbnls89mE9moFRp+xx38G6ybsCJC4EIgQrThfEF8RVSpks2yxEmmIqzPmeq9etHen36iW954wzYdL/YQteg3yFZdM/OYIHAhyrEv2DcW1BqBC4EIIAqUwMW2bnnzTe53EJ5oByZT/GEABkIc5wTbgbhaNnw49Zg0Kdt5gggpXqcO9fz+e1o+YgQLMCViMQ0CrcNHH9HPbdrw8UDw8GbS03lfMR0DPXC7RpIiJUDxwWAIBDWuISWe/h48mKrcemt2QalxCeZB0j17uD3QVohNPfLXX1Th5pt5utblGMcI7wpQrk0b9qZY//771OXzz/nY7V2UVcIomwV3/37aP2sW9+NGDz+ctT+aZVAiCOcaQKg6SmbF7VC2LN9PtCIVAlcdO7JuJ37/vW1aima9SqBrhZpWxAaXLGmzWvK5h/ty5rRCxYrZ+iD65oJ+/ejWr77iexCuEwUEbuXOnfmehHsTBoAwMGFvwUXfQOIreC4AXPdoY1z7SixrOTh3Ll+Hq55/nvovXMj7A+BRgGsM91EIXIjwDe+/z8Id+4ABMwwe4dpmwWqx2MQs2hDbw3WnBqpUUj+g2kKFf+S1BddnLsqVK1e2WVRVh4bVFVZcLfi7S5cuVLFiRT6hcGm2F7KzZ8/m0eQGmhskljuhCcA+fvx4Nouxt8HLFawN5cuHc5ZTlTwGrm4QOHfdNZMzyKLcj3JRBrCqNG78HVWq9Bm/fFWtWoxj7BAPqcA8eBHECzZcFhFjp3XhUy7KcMN77701nERFATHpKLMzku4gFu1Ggevi778foH/+OWHLAg0++uhf+uora+wDBIYSP9gfZLPdtOkKW8hUzCJi6zAdxwY345o1v+T20oJl0W9ULCxcubt3/4m+/36bzeUZy6A+am7Z5hYuPMwu3chejJf/OnW+4vVUr16Mpk/flSMmEzGleKnu3/9XHmDQujDC2omYavTXkSNvoW++2UTvvrvaNh3WMrikIu4SCYCQmEfFjqrETQqIGXV86FOwuGL7AELQ3nUU7sZwA33llfa284kss5UrR9L773e1lftBvCyOE26eWA9cWb/99nabxRd9CC7ialvPP28V0XAFtndRBmiPqVP70oABv1Lr1pNYsKhjhQsx2uKttzpxP27WbHy2tkD/x/LdutWgihXH0Z9/WjMmoj/g+gHff9+b3V7feQfW1iz3Xgz24NgUX355G7dT9epf0IIFMbZ+guNS1whcdyH2wf/+15w6dqzK8aljxqxlV1qb22N6BreDcjnOyHiT3nuvC91//zzq2XM6n3e4ezuKwQUNG5Zht2EIsE6dpnIfUO1in5gK2wBo74EDf7W5TStw3tCnEJagjWHH70hOpZa1L2Gl1lu4cAjXxFXTVZkqiF/cp7Cs1k0Z1l+IPoD/Vf+eM2cv/fzzLlsmZBV3jfOAdsC5aNKkLO+jNiZYxeACtCXEPvrOiROxfH+sU+drKlHiE74PTZ++k4YN+4PbrGzZTzlh2qxZA2jChC30xx9ZNRE3bTrDohv3TrQn7ou43uEWjutJZRlHLLKKTcf/yLaNeXFvfPHFpVS4cDDvn/YeoWr5KhdlM8XgKpCc8e6776aFCxd61ZqrN5zIG6jyIGxhdeCiumrkSLZo4SULL/AAL2uwOOD3n1q0sAqIqCi21O2dNi2bBSoxMwYXL9nYhtaaqLIoB4WF0en//qP5ffpkd6F0EJcbvXo1LXnsMacJbvTCXj7//suukhAfaruIH/ytb1/rvl++zBa0sxs3srV06ZNP0rmpU1l0QJBD4OODJDewUGLZeXfcQdu//TbHtiCClOUFf/82cCCtffddbldl2T7yxx+5umofW7iQXbphmYNlDxlUlwwdyi/KiNHUxj3iO16qkYAHFj1Y1C4fPJj9/Fy4wMKj7r33sjiARVkrVCHsUBoKIA5UlbdRxwJ3dYDzr000hbZTAhfL27t7Q6yi1mjrF1+k3T/8wDGXKn6z2zffcJsCFvCJibbyPXARfiLTgqfcpTnBUqb1slafPjbRpLXgwpUaYDCl72+/cVuNr1CB9v/6q21daAsIN1j20CZfRkbShcxarspCC0tfi2ee4azGS4cPt7Uh2hTLNhsxggcVfu3SxVZfmktVnjxJ4ZUq2QYPavXuzfPC8n5qzBhuT8Ttai24EIs4hxDuaMPbf/qJ/rjnHltiLp7XzroKbvvxRxq8bRtfnz/UrUsbx4xh92ituzHaF9vB9Ye+hPvA4sce4+v9rwceoFNr1nCbc5yvGijIFMQAxwphtvXrr7Od10QMmJQpw8JR2xeV8LUJWE1/sBe4ELPa6drza2/BhcCFBZ+Xg8DNFHgQhMcXLeLBMKCN/4cwRyw1npPwKtCWbILAVccI4L3A+1yqFA92watgSv367Nlx5K+/aNULL9C8O++kSTVr0qJHHqGOn3zC50Wbv+Dspk08OIT7Js4B9hEu0xDa2E+0DfoXxC++44PvENNoQ1iRVzz7LLvhIwGWIxdlxI+r9igQFtwyZcpQixYtOOsjRoPnzp3L1lOtezK455572P0YiTQiIyP5Yd40c8RMgelIKKWlV69eNGLECNq/fz/H4X777bc0aNAgyivwkr1z54cUEBBE9977NRUqBNfpK3TiRABFRGAEqiht3ryb5s79PxY0v/xSiAIDL1KHDjPo8mV0ghEsbHbvXktnz35Mr756lT74INQmfpKTITxe4njLhIS1VLdufZv4SE29QLffPoOuXq1AoaFd6O23V9Hx47No6dKl/EKMl18kQMILLmKT0U54od627TOqX39sDmsvXLiV1cKZW9r8+QsoOTmSevX6ki5e/IFf3iFSsU+wBCE2MC1tGAtvuD0GBi6mefMCqEaNUXT69FV6913cWKMoI+N+Xl9U1A46d+5fatr0E95P0KHD5zRw4F20enU9euihJjRu3Nt09eoeFmIVKkSyIMFAwrJlrTGmzcvEx0+lFi0+45d07AuODVmr+/V7lgoXrsdidNas4Sz6EWe5fn0Qwcs9ISGZOnd+hUaN6kPt2o2hKlXeooiIUBYjV67E00svTaFy5SCun6UvvthAw4Z9ThUrruOXdghHvEA3bPg91axZk5588ikWTyVL7uZ+iJfplJR4atjQmvE0Pr4SXbxojav76adPaPv2/6hhw4/475iYK/TQQ1/Tyy8/S/36DebfHn30Pjp27Kht0GTePOsN7733Pub9Q/mhyZOHsphq2PALFjP4fdSoSfTKK2/R3LkYNNhCzz47hIWNNZnVJBasVgF0f6aIOkwdO6ItrdSunU7Hj1+lUaMW0dq1y7h/nj69nBo2fN42T40aGexafP/9i2jTprm8j5cvL+D9AOXLJ9KOHfHUoMFXNHz4kzYRi9j5A1zQ/Qo9+uhUFi04N82bWxPPwYpcuPAEKl48gd1Kt2zJoIYNP2Vx9PTTn/E8eOFGQjpcA8HBKTR+/FVaufITFlFFijzLfRIWuFGjrCUNVBuD4GDEVA/g2OqzZ1dQw4ZTMgUoBk1+4X4DiySuheHDW1PHjvfS00+/zKEC6FczZoTSypXh1KzZXRQebk10M2nSC1Sz5iHKyAiiEiVSacyYb+ittyA8e1JISFPeT1xPEIJYxx9/FGGhCHfijh1j6fnn76BHHqnKx3Tu3AV68MHvbUmo/vvvFdq4cRt/xz1i4MBR3OcQy7xmjXW/sM9BQW/xvnyDl7L0r6lXr59Y0OH+FBiIbcTyvRKDHG+//SodPrzJNji0cWMhmjSpECUlNaPY2C78+w8/vEzXrsXQ5MlBFBCQQSNHTqUPPyxC99//At9TIHJbt25MISFXqG3bn/iaUfG5N930je08bd36OqWlpVJAQDp17DidAgJieWDghx/KsZhu1SqBDh+ezKEBJUoE0bvv/kzJyddo1KjfqU+ff/gaWrduHp069SElJKRQ4cJo30mUmppMY8f+R0lJyqthEWVkZI3k413o8uVQWr36Tjp8uBbXHS5RYgFdvnyaGjacxfca9C9rSabudOSI1UI6derj9Pnn1oE5s4ABYQzufvLJJ2xhhQBF4kUIX1+EEzlCW7kA4UOFCxemxER4sGQNsiIECR94YqVrEtugvi8suCnBwVS4dm0WaVgf5kC0GKTvxZgYOn/8OM9TqJy1bJ4lMpIuRkdz1lPMc/XkSSrRsCHVHDyY1n31FU1p355q9e1Ljfv3p3jUxAzDIOI1imjUiI6tW0dVb72VUlJS6GpsLJUICKB0i4Vw1SIO8PDixVS2bVs6u2ULzbvtNrpv9WqqetNNtmM6vGYNb/PwkiXUdPBgh8eE+sVIgqkdlCiCbM3BwbxNWKn+fvhhFlPFy5ShWJRIKVaM2r7zDiVdvEixV65QkdBQurhvHyVnioDdv/1GuxcsoEDESaanU6J23aVK0e8DBnBSpaTERLp09izVfOghWvnUUxh5oiJVqtD+BQvYall7wADqNHo0Wxn3zp3Lba1YPGIEHV+8mNJDQ6ly9+78on/t2DEKSEqitNhYit62jc7u2EEdxo6laj16UKkqVajJsGG05ccfqVnPniys/37uOeozZQr3odhLlyigTBm6e/NmfkHe/eOPtOzpp6nagAHU64cfWLhcuXCBYzYRY9Jtxgz6pUsXarB5M1W86SYqWrQoxZ4+TRkREXz+LMWK0ZXMWM24CxcoJSiIElJTKQB9sEgRSj5zxnaerpw/TyGNGlFycjILr7jMZG2KK6dOsVt0oSpVuO8dW7+eSickUFJ8PJVHTpjvvmNxcmbfPpp7331UoUkTdu3MiIzk7aIPXDh1ispWr07XL16ktMKFbeu//8AB2vfVV9wv8BvOR3qRItwnwsPDKQxtsmkT7Z42jZa//jpVvuMOykC/wIBP4cIUFxdHHSdMoF/atWPLZjiSEZ08yfG/WF/Nu++mHd99RwcWLqSbrl2j84cOkaV4ccoICOC+13XqVCry8ccsIuFKnpaaymWMgitUyNYGt7zzDtW95x6aevvttO3nnyk+IYGSg4J4MAT7fnzTJgpBhuuMDEq6do3q3XsvBRQuTJvHj+fjh5BSCfESr13jdlHrL1q7Nj2XlETrPv2U9v71Fw8MQcgmZ85/9cIFXgf6McTtAzt3Uuk6dejCsWO0YcwY+qVfPxaWkWXK8DWPtsM5Ve2MewFY/sYbtPWnn6j/n3+yB0PcuXNcsiclJIT731W4hwcEcNhDxc6dedmU0FDbNIRjYN+TAwJs+26JiGChhnsEQlYuX7zI9xAcKyy4l0+etM2LcxuQOchiQbmjo0d52v5Fi/h8Ivt0elgYnT10yNqH4YFx+DAP+nB/wD1p/XqqNXgw3yMgcFNDQ23rL1K3LuFKr9arF509coQSzp6lsBo16PjGjbTxk084brhUp05U57HH2PoPSztc2bdNmGBbx8EVK3igqUbXrnT96lU68c8/dD05mS3o6ZkDWqk4D5p7QVBGBntKHF+7lk5u3879D67t5Rs14oEktEVqcjJP4/t05mDotStXeLuYjv/Vfc++wg2u7UBkBLeLz4+IiOD7pupXpnZRnjBhAovbDz74gMUryv6AoUOH8gsvPniQwi0Z5YRwwLDkTtQEVOOlGBmUIXztG2Ly5MnUt29fthI3atSISynkFXAN/eSTYEpPD+SYWbz4Abw0Wy2b1pIgeNFEvUmAedLSVEIca5IplSwKlkS83OKlHy+vJUpYR5SQ4KdChfBMi3HWCBjWMWhQIxoz5hWKivqI13XhQoLNEoGXfiS1gQUPL7OwlMLKBSsOLEVYlzMgKPESWKhQEK8Pf7/++gr677/r1LdvPVq1yjqaBcGJF1uIR7QBqF69OO3ebeEENmlp6fxCj21pE0pZa3OWpCtXSrB1CYeEY4f4git1QEB9FoyJiSk8cIAXY7wUYz1Wa1POfVYWKCXeFy8+zJZxtD2WgRURbamAUH377c5Uq1ZpPpcrV6byyzqOW1k5sa4tWx7nNu/c+Qzt32+Nz8E5VOcbPPFEKy5HY0uGkGq1KCpgWVOJpGAR1A4wWPtChqY8kVWkq2kqiyzWOWHCZrbso23V+jEdfaNQIeul/uijLWj//i30zz8nuS+iXdC/rP0va1sQS8ripkD7aD3bMFCCPqAF28W2lJcABCz6sHrfKlasMP9m9SRI432DhRdgOZx7lSkZx6QsyGr7OE9ZQtx6fMqtVoF9VMJKrUubtRhtHBmZPZEXBPTvv49ky1+nTiv4N2Vh1bqJ4Tv2CX3CYjnC/QFtpbaDdeN41bw4twC/ITQB63zssR703XexWVk0Oabbug1Y37Hc4MGdaObMQyxwVZxocHAAf9S2IM5wXOHh1kEv9DltSaTg4OznBudXTbcm3srqg/ZZwTFd9WEIYvQThDCoeXC94hqBazK2BW+HXr2yXHdx3GgLdR4wj+pnwHqeC/HAF/oAmgJltbZuHcbTMRCxZ0/2c4SBKVVfvG/fX9gSGxISzP3GOnCnyqpddVlTWM2P9gO4XjAgryz28CoIDQ2msmUj2YILq3RsbN7Fu+oFLwF4fuJz7Ngx+vDDD7mMnlZQ5SX2+Sxg+cULogKDpM899xx99tln2eKYUfkA+TPwnFfxxQDlj3p06EDfREbSayqMKCqK4PyLIIjRme6BNN7qETK6WzeaP38+DbRLJvnxf/+RJTCQOmVa+uj0aSq0YQONfv112p+aSjVuusk2b/kVK2hK69acpPKLpUuJ8IGHSvPmNKxoUXp51Ciarymh8lunTvT0sGH0/caNtFzjWbb2mWfokePH6aMFC2irZn4c02233cbu3hggULx6993UpGpVGjJ2LCVrrMTjP/yQqkdG0sD770e8iu3391JSCI+5sfjj+nV65e67CXeBDyMjac+1a6QtoFQ5NJS+nT6dlm3YQF8g7nDbNhoWFUV1AgLomfr1acHcuWQ9SiKaNYu67N9PfStWpNmnT5PV58pKd9yDfv+d4BAJq43iwWrVqEv9+vTmzp10GufjySet52P0aK7NfO+UKZTwzTdZx9SuHZWKjKRRKSk0SlO3GUaOwIUL6V64h2a68eKYWmzfTlunT6fXX3+df3ujWzd+L/zus89oQ2Iivag5f/UjIqjY4sU05Ysv6Jf0dHot03rWqW5dur9UKerXr19W39u6lZbFxNDAm2+mb86coac1ffVuDMbceSfd2bCh9Tyh/YnoydKlafmqVdR/6NBsGctfXrOGIoKDqXxmTCnvZ82afEz7T56kRzKrewC81H9z22206/Rp6qHZ5kcNG/K7Lfe9L6wDwuCHjh3p9SFDaGVYGL2a6T4P2pYqRVXXrKFnJk+2HhPa7O23+XrqN2gQffjmm/SUZv2nX3rJYd/L+OILqh4TQ8PXraP/aeYfP34857p5GRbJTGsw+CTz3fqJJ57gv5+NiuJjQvnOzbt20et//22d8dw5+uyBB2jyjz/SX/v20QysI3M9MG7hvf+n3bvp59WZ3m1HjtBNoaFUb/FiGvvBB9wn38gUqs7uEQ+XLUsRJ07Q/9R5QjhFVBT3vWa//kp3P/wwJW7cSI9luh+/hnrX1arR/zKNZK9n9o9PqlSh6B07qLmmnu975cvz/WRrTAwN05QfrRAZSe+1a0fzXnop6zzddhsf0zO33ELj58yh3lOn2uZvX7Ei98mPZs2iVahlnBlP3CM0lLofOEDTihenvTt30hOZbX9vRAQ1PHSInujRI+s8/fwzH1PVo0fpsaVLKUlznj577jmKPnOGntD0GTp6lPveyQsXbOdJ9b1pb75J/+7dSw9q1lF582aa1KkTLUxMpO80njkYKsV+Lbl6NesekWk+qhgeTjMvXqSNmbqNUlPpjuhoCl27lu577z3anlm3GQw8fJjaly5NH164QC9qtqvuESjjqr2eVN+Dt5AWHNMFzTFBD7rEImSjYsWKHmuRRYsWWX74Yaulc+epli+/XG8hejvbZ+jQ3yxhYe9ZkpJSef527b63TJ++w1K79pe2eS5evJ5jvefPx1vOnLlm+/uppxZaHnpoHn8/ffoaL5eamm6b3qrVRMuUKdv491tv/dFy+XKC5ZVXllrq1fvaEhX1If9eqdI4y+LFhy0PPDCX/8b6fvpph+XXX3dbli49YomPT+bPM8/8bSlUaLSlcOHRfFyYF8eA/9u0mWTJyMjItq/33jvb8uijv1lCQt7lee65ZzYvu3XrGUtaWrpl9OjVltWrj1smTZpvmTdvL8/z0Uf/5FjP1atJloiID/gzf/4+y7p1pyxLlhzmaf/9d9JStuwYS4cOP1h+/HG7ZcSIvyzduk3jdeEYsP533lnFy+DY8THCa68ttzz22O/8Heexd++ZOeZ59tm/+QPef38Nt6MiNjaR9wX/nzwZa/nggzWW++6bY5uOtkY7qPU899wi27S77pph+frrDfx91apjlrJlP7RN+/DDfyz33z+X26pZs/GWPn1mWnbvPmebXqrUJ5bNm09bbrppkmXGjJ22359/fjG3l+pj06Zt59/RPhUqjOXvy5YdsdSq9WWO40TfxDRw223TLd99tynHPF98kdVGgwfPt7z55ops08PDP+D93LXrHPcF7bl+++2VliFDFtjW/9VX1mPXMnPmLkvbtt/z94YNv7EsXHgwxzzW4//A8u+/JyxNmnzHx4XzCMqV+5R/dwT6ZcmSH/P3gwcvWkJD37PkxqhRyyzDhv3B33Ee1bXoCrQjrivQvfs0y+TJW7JN37gx2lKmzBj+vmfPeW4zsGLFUUuNGl/Yzlf58p/alsF10bz5eP6Oc1SzpnU+Rfv2P1h+/tnaD2bP3mNp3Xqi7T6F6xofRZUqn1nWrDnO33HNjhnzn+X777fyMqrf4NrCeRg+/E++F6SkpNmWt+/HjRt/a/njjwM52qFnz58s/fv/wu2RG+jvgwbNsaxde9ISGfkh3xMUn3zyb7Z7K/bJ/n6LD9px6tRtluDgd3kdqv/jHvbEE39YihX7yDJr1i5eZ5cu1vtbjx4/WTp2nGJrKzM9Z1JSUixz5syx3H777ZbSpUtbRowYYfE0586ds0RERFhSU63PKVyvZcuWtRw6dCjXY7x69artk5Bgve/if+3vSUnW8xgfH5/t9+TkZP59/vz5lrPHjlneI7IcWbvW8hGRZQwR/43P5Jtusnxdu7Zl/7x5vG8r3nvPMrNPH8uqDz/k6Z8QWbZNnJht3fikJiZazu/da/t79++/W8aWKmVJSUjgbU9s0cKyZdo0noZ9Wzd6tGXePffw9rDeY5s2WTZNnGiZfvPNls9Kl7aMDgjg37f89JNl2YsvWj4PD7d8Xr68ZdusWZZtv/5qWTNmjCX+yhXex42TJlk+KV7c8mFYmOXHbt2yHdPowEDLqT17eLtpaWk8/6bvv7dMat3a8nWdOrZj+iQwkNeJ+bbPnm1Z+f77lj9nzbKc2bLFMrZsWcvEVq0ssVeuWOLi4rgdcUyY9+fbb7d8HB5umXf//ZaEixctG774gn+PjY21jClZ0vJr//6WBf36Wbb99JNlVr9+vL2Fzz1nObh4sWX5M89Yjq5dy8cec/RotvOE7WRr38z+ov4+uHIlrx/HFHviBK/3yuXLtuk4zmPLl1s+r1KF/z66YYPloyJFeB1YF377oX17y7rvvrOcPXrUcnbrVsuYQoV4vzEN7T6peXOe/9CSJZYvqla1rXvjd99Zfu3Wzdb3Po6Ksvw8diz3vYv79lk+KlyYf1/8yiuWr2rUsOz+5RfeHxzT3MGDLYtefNGy/K23LPMHDrQd095Fiyxjihfn8/4xkWV+v3627X1aurTlwIoVvI5xRYtajq5fn61tVr34omXx8OH8/d/PP7f8eOutOc7Tqd27uY2uoe3mzbNMatQo2zrmDRrEfRLH9GX16pad8+bZrqdz27dbxkRF2dY/pVOnHOfp0rlzvP6rZ85Y/nntNcu8IUOyrV/1vW9uu83y51NPWRa//LJlXLlylu8bNOBp8//3P/5dza89T/h8VqmSZf/ixfz7xPr1LdvnzLFNw/UEsK/qN7TXZ2XK8O8nN2/mPprbPWLpyJGWpSNG8DGt+fRTy089e+boe9jn/UuX8veJtWpZjmV+/zgigu8n+P51mTKWU5nf0SfRLmh/MLZoUcuRdeuyzt3771t+u/tubs/LFy/yvKf37+d9m/Pxx5avM/svPr8PG2b5+6mneD1bp07le0fMkSOW94OCLH+PGMHXfPSuXbwO3BOwT+f277edpz1//WXrxzimf954wzL3oYdynKet337LfejDwoX5ulHXU1paWo77Hvr7p2FhlssXLljGlS9v2Tpjhq3vnc3sc+ozvmFDy4x27Swfan7D5wMiy4G5c/l/HAv2e8Zdd1nmDhxo+WPQIMuYyEjLH8OHWy6ePWtZ/fHHvPzsHj0so4ks544ft8ydO9fhPcK+79n/bn9MuT1HTZ9kyt9BHB7i1VD/0Z5Zs/ZwuZewMOtpQCIbxJEiXg7AcKS1YClKl7bG3CmefvomatToWxo9uitbTWDJ1FoIUUbkl1/2sKVy6dKH2EL04Yfd+AOwDCw2sLD06FGT3nmnMzVo8C3X7IWlBi6vsFK1bFmBLTY7djxBM2bson37LlK/fvXot98OUM2axTlO0z55BdyTEXeJOquwjo0ceTP98ktW9r/XXuvI/ycmwpXcGkMFi5z9euCaPWxYS9q8OYb69KmbbTpK3MAag8/nn/eiwYObcuIgxPA+8EBjnhdxlu4CizYsx9qyMY7OCdpDG4Or3XecD1jLGzX6jmMUe/fOciOEJUxZmGGdhGUqa1ohm3UX246IyLpkYWGF6zFiFGF5X7v2f7a+A+B2im1i39H+iltuqURjx67jvocyOfff3zhbrCViF7t1+8lhn0VbZq/fGuqgLazuxeg7f/11kObOzUosAuB+DBdolHHq2rV6tnMJrwLEDMPjALVqP/kEdoPsaEv+wAqsPWYtUVHB7LWgjcHF8cGyB9d+R2iPD67b9lZs58tYspXDyQ1tHLE2BlcBCyTaEBZqFX+rzimsnlhW+7ujGFzEeGvRTlclghRwz1+0KGvkFmWusmJwrf1z5crjNHBgA/rqq9vYCgoLL/oKYtz/++9/2TwgtNeDq7bEtY4+0r599twLjkCtX9Sr/fHHHTR4cJNssepqX+Hpgrjg22+vTT/8sJ2tr6qeLe5ROFfoY2hXlOmCKzLiv7FvqBW8Zs0Q6tDBeq9Q7Yf7p32dXDPw1FNP0a+//sqWA7gmw9oAF0RfhRM5Ap5Z9sBNGR9HFmlHYN6y1apRyfLl6fK6deyeDJR9P373bo4NrdKpk9V9Ghlgf/mFgps1s81TpWNHh/tSWpNwqsGdd9KWSpU4Cy0y3gYnJVExZFjOXK50s2a09+efKe36dXp41Sqq3KoVVWvVilppkvnArU8lour03nv0a9eutPz++20Za/d/9x0nIkKsb9/vv+fYudUvvkjt3niD1r/3HpWvU4djSSvZJVwqX68ebTh6lF0ja7Zvz+6o3TWxtE0zM+rCklceGV/Ll6fIihUpKtNCBdA38Onw8su04L//6NaPPuL44zYay3DV5s3pxLx5dPMbb1CzBx+kam3b0qn586n+bbdRte7dqXaPHuQMuNc6wtbuNWrgxkMBmZZ37Fsxu7JW4bDYwfU0MpKuJiZSicy4SLgx4reS5cpR0PXr9BPWhWdJo0Y2LwH0D1IujYmJvG617ajSpa3JxgoXprDQUAq8epUiypRh1/iU8HAKSkykQkFBdHDCBOo9dy5V6dLFdkzoe4ivTTx9mspmWv6w3kJI/IMYS/SdwYM5MZPaXvESJSg0LY2mNGhA6devU5mqVamotv8FBFBgQADPj/mwr6r91HkqXKMG99/ApCSuoVqzW7dsfbhYuXIcAxl/+DClnz1LdW69lWPJAc4rXb1K4UWK0LmlS6lut262e4PaTnqhQrz+oMBAjiNGOzq6RsJLlaJAuJNGRrJrPB6QKNeZdOQI1Xz44WzLqPMEigQFUdHM69ySkEAly5TJsX4VngASIiJI3b2C09MpIjw8x/z294jQkBBKSUqyunanp2c75+o8lapQgQLj4vh7EuKYy5a1/o68PugH4eHs+h+BayZzWawnNDWVr9mM69e5b6lpJcqXp3MrVnB7pqKEGe4NVapwNvewChUo8dQpKhIWxi7RQQkJFJVpZYxCEjyUiVq+nKq1aUOd3n2XaiC/UKNGVK5mTdr02mvU7rnnqExm5mocU5lq1ciCclqZ24aLcrESJXK0C66buO3beZ+rNGtmy8AdFBSUY94UvK8kJ9PZpUupSEgINYNreaY3F64J7nMhIdyXqrdtyzHIpWvX5hhbxAYj7hlJwpBJmd900tOp6f33c0wuymftnDiRWo4cSV3Gsn8JFS9dml2FkYys0PLlFJqezufR/jw5wtHvjo7JGSJwvQxepPEyv317zqQTeLG99dbq2eZduzbalpzp1Vfb68p2iJdTuPch5hIvb/Yv2BCmkyf/xcLG0fqUwFbUrFmCfvihN9erxItqjRpfsLsokkPt3v0kJ0WC+y6ASIF4+Pnn/tlecLUCF8ITQhjuvK5QL+sqaY49H3/cnV9M7Y9B+yKPZElKCKjkRjcK9ke5M0IYINGPPdo6xsgOi4yxCuwDpquEPHAHR8InrYhVyZ/gAqp9cY+MDLX1hwMHLlGZMlkvsDjPiEVcvPgIDRhQP4fQQxtA5OMFH+dMcccddWxuqdOm9csmEuCiiXMKsJwrYQaXUHsRBdBn0BZ//42Mv4VyDC6g/TAdyYQwKONo2rx5+/h6UOdTC06p2gfsr9b1VQvK0kAkKrdyLIO/Ic4cZeu1X7cj4el8GTK4TIDLZXAtYDraAnVxtQIX5wWhAdrfVdtlCVycm+zrtLriJtoErHagBveQDRtO04oVx/h8QSCrNlIDH4jTR6IwuPYDXItqYKxp06zMtmqQY82arDgZ9FNHwr9MGetgh7MBBy04dghVtIn2+gEqw/yTT7aiUaNW0E03VeJEYsguvWPHOW4LhE8cOXLFdv3efXcDTjIGVOIuiF4FXLMBEmJNm2bNGmkmEBeL5E9Hjhyhzp07cygO4sK8IXKdhRPlJRAzx5csyfE7XvqQjEUlesGLF17AVKkgvOxpy504g8Vxt26cuMk+YynANlQ9TmRatQcvftosy3jB7fbttxwniVI3yEqLRE1IuNL+/fepdj/rvfeB9es5zhDxrf1++41Frz0QxRAzSJ6Dkj+5PdeQ/RkfR1Tu2JGePHs2WxkZBRINgdqZiaxU4i5s90bhLLUWC58XTszjIAM4jh2DBFy25vx5a/yt3XRtCSiUQVJwGZbMBDeIA1QJpgC+q2l4UUfisGCV2CnzHCMONKhQIc5gm61NKlTgeGgknqpz991Z64yI4DbEvt5uF/6GhELYT5x7oErkKLKVt7FLYqSAYMK+IQETXMLRT7QgUdKVgwc5Frh2//42caumAVwHuGbQD3Og+hAqJiQk2LL92oN2Sjh6lPsC4mrVfiN5lUrw5RDNwC+Xt3EyAOL2/HbLaBNZaSmCkkHnznFsO/qAypaMJGJICIXrCkJW/a7aD31UlZbSnp9CmiRTGKhBH8C54rYqWZKv+81jx1Kbl1+2JpnSZlGOjeW+hD6G+1WdTBdclCFCKSRt1mre99KlbdcD97Xr123nNtt8ZcrwceC+ZF9eyh4cC9rpwC+/8ECONiu5SoiFzOK4/lDfGP0P1x0SuiG2Hn0A+6Myhqs61GBVZrky1FzWbg8guRmuA/SbvEIErpfBiyuEhBIN9vTpk5XOGy95kydvY4vdP/88Qu3auU7Jr8UqdlI52Yr9Cz/Ktjz55F8sNvTywANNbN8hgvAyjGOARVoLXoZdWUchcMEtt+R+LBBoeDFWyzgSV85ig1essJazUdO7d69hi3+8USAilAB19jKukiIBCI+uXbOXW7IK3KwMclrrKCy4Knu0NTNx1nnCd4gRACtSy5ZZI/KIPcY5X78+muN87UFs9pIlR6levVLZ2g0CDwMSLVtmrzGsrGDWUjbkcFAGz0RlPXVtwUWN1fNsJbZ/GUNbwAoJwW7fx5V1F6LEWb/SikPE+ioh4syCi/OCvoH9xgCCo33OLuDdEavKgptCJUpE6VjGtZDGoBMEKazNiJFX1wQGFLD/aD8kp4J3hQLXKM4JLOfOLLiqLyE2HhZRrcCFcEQ26ZgYa9IwJQTRL/buvcjTYfFXYNAAWdxxfdgnpsMgB9pe4awtlUDXK3BRggttZ99vYLG9cuVl3tf77mvM/Wjz5sf5nKv8BMqrBfkHlMC1Rxs7rzwnbrutFj388IIcWdx9DZJJtW/fnmOpEYO7Z88eevXVV3Pko/AEdevWpXXr1pEvKdWwIe2YMMHhNJQ/USAbcmBm/VJY1W567TXd24CgQFkXWxblIlk1xpGcBS+PKEGDF089oISMKiMDUdvk8ce5vij+14KX1wc3ZFU7sAfiAhlOUepIz6AtXj5VWRZHOBK3oO1bb1Hj//3PVhMWL+69pk7NVu/SXbBNCE2Vfdde9AE1SAFxCFGiFR08vVQpLuniTOCqEiX2JZ20WZSP/f03CwyUP9IK3BPLl3OJG/v2hYhDVmpklS3d2OrtpHhg40YWmfZAKCBxk8JedPAzQ2X/dSJw+XhLl+ZMtrjpwWpv3xaoS4q2UmWMFDhvyGaNMlrI7KzEiP0+AC4JmJjISaYcERwZyaJEZbRW4o4HEZzsN6/frkatNvuvw/k1I8X2g0u6lnGyDVhskdUc2cDRB9UAEs4rBi3w4VrFmmudhdilS3xucghcTZkg9AsIZe0xQ/z9+9prXGuY2yxzeyqLMvoRhKMWXG+orYxsxlr4GgkIoIQLF7hEF9rR0XWtrhNVnzY3witUoMO//calqLQgUdQIXJvFi/N1hrbiQQ0kef3oI5uQ76qJ973lLWsiS4AsyuperVBth/1GWSOUaiO7RMH5rkxQQQJWKLxk4UVJmzBFudcq8JIHKywsdnCtM2J9xMsjXq6tlpLsN1NVVxTue+7Qv399toS8+WYnw8uqF3OtZcQVBw78Xw4RrYcuXapzgh4FLNn9+uUcZXcHuFFCtCrRp7WGOrLgojwTLOr201XJEQhOrZu51Q05yaEFF+IXL9qwyKEGaatWxbKdc1jk4PoNIWkPzjv2V9vHFHBLrls3u6UAwheDAhA/AK6orl2UnVtwYfGDaK9WLafYw7nZuvUsb8s+QRSmwR0eog4DQ44wYsHFoAIEM/q+SlambV/Hx5clPPW6G2eV/DHi1mz97kiMApUoCeKyQYOscwVRC0sm3M+1JZKUxRUi1rkF19rPtm07yx4aCrQ1avUCVZNWeQSgf27ZcoYFsr3lG4ns7rvPmjXa2YAP2gYDMY6OUQlcVbbJFer6xn3SPkwD50AN0GjvA/gd/UMbsoHSayj55Gh/tChrN46/S5dq7EptJpBUCglXimWOuqO6gLY0Xn4DFly8iNe4884c0+pkuugCiFsIMtRwhUBQL2V6wAuysto4eslunOmO7I5nEMqpwDLS+dNPbS+9esExQajYvxg7o/Nnn1Gr57Oy2+sFVpZKHawZ/RWoO4oXX08AsYEX5wvbt3NWV3vwMo2Xa4g2WI4i7OruKguusihXbN/eNg2ldlT9W3sLrta6i/Is1W+7LZv4hEvmyeXLOUNyjn2uUIEt95gH5Y60QPAqK1wOgZt5Ldbs3TtnQ2iFmQuBi4GUc5s383mx73OwgKMt4BaKQR17MB3XgKNptn0AqDmbkMCC2BFBsOBeuMDb4eNX5Y3s2tjZsxQljpCxOTfBqtz49Qpi2zFoLOEhDtoRfQXZheGZgfsC19vVWHC5vJNdP1N1crFOWPu1/V9rwT23bRuHLmhR4g/lfrR9GH0Q9xRY9YvbhXdADGNgyf5exXW9NVZPZ8eoBK5WWLpCDdDZeysAbA/nDu2mxC1ACSqcI63F9/mMDGqmSWKlBp+0Ayo2gVutGt+7kQ0/rxCBmwdAYMAapRVGEI14ydLetCCKYLnB9ape1vSirHnOYgDj4l6lL77oRXlN/fqlOKYX8W96cOY66kvwEo52hQUHMdJat3J7gWut53w1WxytsoahxA5+37zZ+pJkL2IB1qF1gVYxuBB8OMdly2a9lOM8Y59gddJa1hSdOlWzCWq9oP0hcFEP+P/+z1pqyZm4dGbBVfsP4Q0x4Wg6BBNElb3lD9PgfovBAOcC1yoO4SIL13nnMbghHM8LgQOrMoQW9tm1wM2yULvjouzMFded7WQJ3AvZLJzWONw4HkjRijkMUOBYIegdnRtlwUVMMtzkmzfPErgQgAsX3s/Lw1NDK5xxL0Lma1h57Xn22ZvZYurMim8t4WCtyeuor1jrRcNCmHsfhSBFiMS6ddlLwrmDI4GiBL5CW2MascdqAMssIBappJ27mjfck80CLFiwYjYcbC2XBvDyiZesiu3aZZsXrnoQO8rlTi94CcdLKF604bZp/1KOl9enNHUe85KbXn01m4usK/AyCldJs4EXcVhwjy1ezC/1jlAiFgLR3lqlRB0E033//ceDBgplsYWQTbh4MZsLNKZhcARi6wossU2yPNQAzjPiolVdUS0lMoU42lP7cu8KiCDsP/6H27mrgVRnokW1xdnNmx1a7VRbwDJpL7y1Ahfi2BE5LLhOBoLgogyBhePBdnBtYBnst9Yt2sEGuC6bGjDS46LsjgVXiWKnFly4KGcKXK2FU1lwWYRmuuYrCmssuPaDDxC/GEBBHV4M1JS16zMtnn6a6t9/PwtZuPXaBG7mvQj7glhWLViHcvO1B4N0GGBwZe3HQAMGavRacO/85Rd6/OTJHEL7Rp+jSmhrrxN1ftCHa955Jw9AoaZyXiACNw944YW2NH16/2wvsXjJtu8ceNmHILSWOTH2cFLxmM4sWti2oxhZbwPBDsuvJ2JhfQWEAUqszJy5i1q3ruhQhEPgQgRDHMJab+9mrVyUcV7tLezKgouHBlxPtW6nKgEVYoBVOR2FWg/qyDpq327datD+/SNYhOgFYgYunNhubuISx+mon+Kco3/v2nU+h9BXbYFpjgQspkH4OZuutZiqUkTOLbjBbKnEPqhlrC7KuVlwrd9xPXkintb5MhZbOzoTuLDS7tuXXeBisGjPnvNcDkcrRJVghOUU+2F/nOi3EG2wrKMt7EUl9gnrXrUKAjfrvMF7Ayj3Zj3AworjwjWhyvc4OkYkXHv44WZOz6E98O4wem/UA9yb58+/N9tvn37and580+r6OnRoC3r//ezxUb4GpfDOnTtnu/aXL19OJRy4feYX4L43eNu2bC/zeLFzdO9TL3paN1UjAhcvYcDeqsVxtjoTnHiapsOGUZQLt2N/AHHBiAuF8EI8nyPYDVkJKnuBi2kXL/KLPqzBWjipT1gYC1wIF63rKKy7AC6isDLZxxQrMaVijrVAUMBt88FN1hrhelAWXLXd3CyPrlyUL+7a5VjglirF8dwQp86mn9++PVcLrm0wx4kFN7hYMb4m4FqrBC6LVovFtYty5jPOJnBzs+B6MQY37vTpHAIXdXcv7tnj0FOAY1pRSxmi2V7gZsbUou7x+W3bHA6KRNWsSaf/+YePScUpo31VTLmRmHZYW7UWXEdtju3Uf+CBHAN9zkA9XLg8e5pb3nyTRmhi5JVVGZZixCBjIAGhGBiozAtE4OaRQIKlRb3g4WXOWRwgXmQhDuwtW/otuDldlIUbA+cCL+ybNp1x6J4MVMKezZvPsPXK3qqoXJQdnXdlwYXlDQmEtLGRcOFF/C8sefbJt5Sl0F74aoGIcWWxdCRwYS12Fq+tLLhKtDjrx6qdHIlUJf7txRnQCh1H4li7D8igDJzF4FasWMiWgEglx8J+52bBdS/JlDaLsn6rr7JuOtoO3PonT97KVmrEECt69qxJixYdyXRRjnIYL+7IRdlqwU3izMEQslq3XW2CuZUrj1GVKpHZLMbwwkCCKSP9CINC1n1J4fOqjW9VYDBnypQ+5Guwv6pWtDY/wjvvWLOpmpGPP/6Y61oeRdKi9u1p8ODBNDYzc2V+BC9xcAlVL7EQn85esG0C100Lrt6XcsEYEA4Qtzhv9gI1m4g9f57iTp6kCLvYUU52Ex3N1jNHVk/liox5tAIXrp/YJgQhzq2zBFzOhAcsehBEhgTu8ePOB1jsLLjO+rFKjuZIpMJ1WuHIDV9Nz82CS7lYcIM0+wYhray3wJXAVQ85iFWsW7kG5za/EQtujoECBwIXceuwtCL2E2EOikqdOnE/OblypUOBiz7oyH0cx4KBFLgpxx496tDVHn0F64W41br59l2wgBoOGWLI4MMW3PPnc3Vn7/XDDzks0XkNXLntk8dhQODelSvJF4jAzUPUSywEkLOXbAhcI8mg7C24esuUCMaAuNyz5wKfO0dALMDlEyVMHLnlYnln7rHKggvrLV60tQIJy0Hc4mMvZFV/0mbSvVFgDUYfcmbBVUmYcCzAmZh79FHrqKajhGGI23SUvRvgxo9MuMC5yLbuA7wVXCUea9zYKtJiYuLsLLj6k0zpczd234KrBK6j7SAJEtyQUR5Le4ywzMNtGefAkQVXicqcFlxrFmV4A9jHPisQC4vMyPbCGV4Y2sRzuYF2hHhFUiiIbT1tIhijVatWtHLlSpo5cyaNGjWKk0w1s4sHy4+ol1hYNpxZU2/UgssCNyDAaTImwT0gLGE1c5Wkq2yrVpxRGu6d9pZJLK/ElaNzrxJNwWJn/7KPZWHRRCytfcZgNaChklzdKEhIhnU66396siiDJpkx346OFXHc2iRb9rR+4QX+3168Zd+RTCurCwsurG3VelnD2zAPLLhw0WXRqhFvjo6RxTAsqzrFam7W2Nysvo7aEZZKxFZDlGpjr+HGD8tizPr1OftKpsB1dG6wTfQfDJZkpKY6HKiB1RJuuPbHULFtW7rNYAZ67Bvc6l2JeMExInDzELzEQgjhxd2ZwEUJDmdZhHNbN4SJq6Q7gvtAOMCy6UzgqsRNf/550GEyLyUoHLlXQkzi3P3ww7Zs1lsAUQsRBOuvMxdlT7psKsHkWlxabKLFmafBY4+1oGXLHnIYHwtL2alTz9GHHzp2+fzyy9u41rIzsiy41gzKzkZDsW8bNgylWbMG8jxK4BpJMmXcgqs/MZWy4DqzbqLPzJo1wFaSS4Fz8+67ndlCan8sqqQVPvblrFQMLhKmOSvF9dRTbWxi+Ebp27cu/fLLbqex2oJ7nDx50va5evUqNWzYkBo1akTXrl3j3/I76mUZ1jxnSW5gQcFLKoSGWwI384Xfn0NrzAjOCSyb9uV/tCB+EZmOEVNob1FVMX4QVhAs9iAz8tavvmK3U60FF2Bd53fs4P/tzyvEEdAbY5sb2sRCjrCPwXWVZAqxxg0eesjh9HtXraKhR486nAZvB7j0azOMO9qP3Cy44I6ff+b6wCquNrcEU/YWXL1i1XAMrmagwNV2unz+Od31yy85slm3Gz2a/7fPUI3BEGTxxsdRWR7E4SLGFm3maJtlW7bk40e73ii1+vblMlGIH3cVry3kRMoE5SF4WcYLOV6Anb1kd+1anTN2GgViB5aq69dDxILrBZRAtc/eqmXIkGZsIYO4s0eJU8dldYryef/yy43UoUOVHHGTyLiNsjm3346EAFk3TCWkwsM9N6ChkhY5j8G1JkfKTbRAsN16a41ct+MIDAIhNtMZyhqrZzBH1WzVWp5d7bd98idX7t/2++OOKM5t/rvvdpwV8Y03OvHH0UAM7gNI8GWfBRt9CS7wiBN3ZvVHP0cmc3cG2ex56KGm1KXLj9SiRXmvxM0WVFq2bGl7Qb906RKFZGb4TE1N5aRT5zPd2QqCwIU1zpmrHGq9GhWoWguuuCd7HmXtcmXBReKbjp98wuWV7N1aEWerrK+Ozm3de+6htZllSxwJXCSScuSeDJdnT6Isgi5dlHWUCVJWP2fAw6CYgwRTijK5eHSozMVpLrIoA67Z2r8/nVm/3mrxzWWfed2Zx6g3I7I2izLEqqM6yblZfZ1tpxwEpwPKt25NLyj3KwcWXGSwZrFqB/ogBC7mc9QP8RtiUT0hcCt36sTned+MGQ5jggXniAU3D8GLLF7IX3mlPfXo4Tyew51RY4idkyev0T//nJQYXC9Qpoz15u/Kgos42w8+uJWqV8+ZMVpZzByJK7ifwtoJIGTtxRPECMr92Ist5bbqSfGQJXBduwc7KxGUF6h9QAyuswzK9mhdlHO34Fq/w6puNMmU/hhcbTt6zrqJvrJmzUk+VvvasiozO+oPu3JrR/y0fTyqO7RqVYH69atHTz+9SCy4HuTChQssYh955BEaP348JSQk8GfChAn06KM3nmHa7MAKg0+9++7jjKWefI6ywI2PpyO//ebyhV9wD2WBdWXBBW1efNFpEioIVGdWrLZvvpnlTmtnkVQuykYS/LiLEtfOkkxprZW5CVyvotOCay9CYcHNNdmaJsmU0YRR7tTB9aR1UyWZgqBH7VaHFtwDB3LUabYfFEAypxsFbQ4L9BK4q+eS2EvIjgjcPAQJdxo3Lku9e9fNEeN2o+ClesmSIyxwk5M9Oxop6LPgusKVi7K6US9YcC/Nnp2zDASELayV9nGT6gXOkzHXql+6suBaXZR953aq9sGIO76yzOYucLOXQdKfMMrC111KSrqudtFrwTUKBlJQOqply/I5kkjhbxw7sjJ7Mm7bFRC4aHex4HqexYsX02OPPUaBgYH8GTp0KC1atIgKArCqVOnalap17+7R9eKlGhmU17//PrvSCp6liA4Lrp51uHrJ7zFhAnX46KMcv0PYwlLpLLmVJ+GMuSVL5ppkKiM9nffJV6IlQEcMrt0Cthjc3FyUlfiEtdeoWGUXaD1tkrn/fAx6a+fqAMIVx4k4W2RvtyeseHG6tG+fS4HrSWredRfH+wIRuPoRF+U8pH790rR0qeNYihtFK3JKlpSRZ0+jBIErC64rIBjDwoJciitkbXUE4inBLbdUos2bj+WY3r59drfmgmPBtcbg6iEri3LO5EuO1g1yy7hsv4yqZawnSZw2JtiT7aiyeT/wQGOn0xFL7iwG19OoLNoSg+t5UlJS6MCBA1Q3M9PqwYMHKTnZ2gfzO/evXeuV9WpfxI1mYBY8Z8F1BYRqRoo1OZ8jIqtUoZtefjnntjO3iYERe6p27+7x5D3hlSq5jMFV8anAlxZcdlE2YMHFfuuyOmeKz1zr5Wrmt1ljr17VlSCO2xFlixIS+Dg81Y5K7COLtyNXaVhnUW7KWTZuT4OQC0ffBdeIwM0nKEvTe+91oddfd55UQHAPJQjcteDiRgwLrDsv+oiHhDBxNHBhsVjjjTwFSsI0a1bOaeyp1vLoTxZcvS7KSggDvVZqtT/IhA23cT3uvepZjrI9nkjopGjevDzdd18jrtvqCGwLhqm8suA6yigueIaPPvqI2rVrR02bNuW/d+7cST/88IM0rwcELpIEPS4WXI8D0QL38hux4MICm3zliuHlVLKgOnfn9JK6e8kS8jSoSVqiXj2XDwDEVAJdLrxeAO8lKk5Uj0u+clHWZcHViGE9rsPaxFso9eS0hnD2hazeU5n9wZODUs2feoqaPP64w2mw4IK8suBq8wMI+hGBm09QFlxXyXsE94HggwX2RkQdzo2ysBlhxYrBhusiuwsE2rZtw5xOz56syTcWXCVWjcTgKospRGhuSaa0Flw9x6jaBBZcZ67djvYHD+bYWAhc433CGRCuM2YMcDod1v5t285yCZ+8QIl3JF8TPEvv3r1p3759tH79ev77lltuoVKlSkkz3wAqyypelD2VUVfIft8rUq7cDQkDWEZVXVAj1BkwgJ6Oj88zC1i3b77JvYROXBwLy1xrxHqLwECbaNJlwc20+LIA1ZFkSre11y4jcrIRC67FQkmxsSy4PdmOt375pdNpKi7XPpGZN0HcrwhcY4jAzWcWXBG43qFp03K0erWxAt32IL4WiaiM4qherK9QQtHTyZGM7oOqg2vEgnvpUiIdOnTZZYZmdXzGLLhZ4lklcsp9GeuzHAK3WLG8GyhACaZXX21P5cvnjUucul5E4HqH0qVL01133eWltRdcCol7stfoM28el7Bxl2bDh3Pcqjv3ItQ+NQUqltWXCaaUBTezLe2TcrkSoTEbNlDde+/VfYy6LKuazNIscPUuAwtubGyehhRU79WLsyTn5bmDwEX5K0E/MkSZzyy49nVUBc8AgXTTTdmLgbvj/qsyH/srZkoyZSQGF8ssW3aUMwu7Enfa8Qu9FtwsF2VYcPUJXOUKjbq0ekWxp8grcevrbQqCuygXRMHzoGSLfT1SI0Ck3oiLsxnQJmDyadKggAC2CqKmsC6PhYAAFqyn//sv1wRvyktJt4hXibfS0jg2WZcFN1Nww0U5rwelEJt7I/3YKOVatcqzbeUXRODmE1JTrSNfeeV6KBRMspJM+c5F2V0LLkr45FZjWlkc09MzeH69FlxljTXmooxlkj3qomxGzpwZSTNnOnebFgSzIQmmBK9iVPx5bTesAldXBuVMQQkBikRfxWrWzG3lxlyUM+dHBmWgR+CqdoSLcn4flLr166/p8RMnfL0bfoV5fB+FG6Jhw9J02221dGV9FYQbt+D60kWZNDG4+rMog9yyB6v5kEQLGLPgQuAacVH2jQU3rxHrrXdITU2lEMmo6XGaDhtGzUaM8PyKBcHN+FSvkSlw9cTf8uyZVl492YO1ccZGLLhwTw4ICjJUWsgXFty8JrhQIc4QLuhHBG4+AS/WCxc+4OvdEPI5ZrDgKvdeY3VwrcI1t6RUykVZlfzRU6NWWybIiAUXIt2aZCp/C1zBO3z88cf0+uuv08CBA6lGjRrUsGFDatCgAX+KmiXW0A/pPn68r3dByO+YxYKbmWRKTwZl7QNST7yuuxZcLhEUGakv30lm3G5BsOAKxhEXZUEQ3LLg6hF/3nZR1ptFWVlmc7P4qocqyglh3uDgQN2C22rB1Stws8oE5XcLruAdIG7B7NmzadiwYVSiRAlavnw5jRDroyD4jQXXVyWC1H6ghqxRC66RjMt644zVunWXCNLE+RYEC65gHLHgCoKgm+xlgnydZCrNUAwuyG1+NWgMgavXQq1cpmHBRc1iX5YJEgpG5uRWrVpR69atbf/XrFmTP5JRWRDMj2H3Xa/tiPEYXKDL4utGkinAGZF1Clw1UgwLblT16vqWEQoMYsEVBMHNMkH+k2RKCdfcXZSzLLh6BbzWRdlImaD0dGOlhQQBHDhwgJ577jkqVKgQTZkyhdq0aUOVKlWivn370ujRo6WRBMHsWEdFTZNkSq+Lsno+6rXg2qzUel2UiazuxjqtsbYY3NhYseAKORALriAIflUmCNZYa5Ip/WWC9Looq/mMWnCVi7LeJG94MGMbEMYicAUjwBW5R48e/FGcPXuWNm/eTJs2bZLGFASToy2hE1HpxsoP3hAqBlenizLm1y1wYaWGiI+PN27BjdRZDcRHdXAF/8CnFtxDhw5R27ZtqU6dOuxmtWfPHofz7dq1izp37kz169fnz7x583KdtmrVKipcuDA1a9bM9klMTMyzYxOE/J1kypcWXKugNFomyIiLMsSqUQsuygrpjUu2li2yZmrWewyC4Ixy5crRnXfeSe+88440kiCYHZNkUcazKy0hwbCLsq75YR2Oj+fj1J1kCtnh4+N1xyWrOrjsZi2J9QQzWXCRGOPxxx+nIUOG0Jw5c/h/+xHohIQE6tOnD02bNo3at29P6enpdPny5Vyngbp169L27dvz/LgEIb+CZ1BychrXXfZdDK5VUFrLBHk6i7J1PrgbG7XgGrEoYxkIdCSx0pPIShAEQcgnmCSLsorBDdVpMTXqooyEUcCIBdeQRTmzHdOSkiiokIT6CNnx2ZvV+fPn2aXqwQcf5L8HDBhAp06dosOHD2ebb8aMGXTzzTezgAVBQUGcZCO3aYIgeB7lWgv80YKbexZlMhyDqxJvGS1bZM0CLVEigiAIBQkVO6o3w7C3sygbTjKls0xQ8rVrFBQWRkE66nWrdRtKepXZjmmJifpKFwkFCp+9XUHMli9fnoKDg20dtUqVKnTy5EmqVauWbb69e/dSWFgYu19FR0dTkyZNaOzYsSxkXU0DR44coRYtWrDwfeSRR2j48OE59mPcuHH8UcTGxtLixYs9coxJSUkeW1d+R9rKP9rp8uVLtG1bMofirFmzXF+tOg9z4EA8JSUl0+XLqbRr1zYKCDiSa1vt33+W/9+yZQOdP+/8QRgfn8b/79p1kJKTM3S19Z495+n8+Ut05Uoi7dy5ldLSDulqRxxHYKC+beTnPuVPSFsJgpDfLLhGywRBtOpZd8q1a7qtwzYLbkICFdJb0zazFFG6WHAFB5jefJCWlkbLli2j9evXU4UKFWjUqFH05JNPskuzq2kQthC9UVFR/P/tt99OpUqVonvuuSfb+keOHMkfBbJR9uzZ0yP7jpdGT60rvyNt5R/t9NlnF6hUqZIUEXGRevXq5ZN9KFnyDIWEHGOraefObal164q5ttWRIwh9OE49enRxWcoHsbdEm6l48XJUvHghXW0dHb2V9u7dQydOxFDnzu2oefPyuS4zbhzaMZyiopJ9fo/wdZ/yJ6StBEG4UVTsqN4Mw97cDyNZlJUIDdbhDhygBK7O47PF4F6/TuEVKuhehl2UExP1uzULBQafuShXrlyZYmJiWKQCdFJYb2HF1YK/u3TpQhUrVuTODJdmCNrcpkVGRrK4VaL1vvvuo3/++SfPj1MQ8qOLsq/ck+3r4OqNwU1NTTeURdlYDK57ZYswf6FCph9jFARBEDwIPzPMVCbIqAVXj8ANDOQYXN3HlylwkfTKkOCGqzcErsTgCmYRuGXKlGEr6/Tp0/nvuXPnshDVuicDWFyReOratWv898KFC6lp06a5ToN4zsjI4O9xcXH0559/UvPmzfP0GAUhv4HniZH4VO/sg3FBmZSU5sU6uChpaExwSwyuIAhCAcVELsruZFEONuKi7IYFV288rbLgwkVZLLiCPT41H0yYMIEzJ3/wwQdscUXRejB06FDq3bs3f2ClhesxygkFBgaytXbixIk8n6tpEMzfffcdx/jCSnz33XdzHK4gCP5vwU1JSae0tAzdSZqSk9PdSDKl34KrBLQRCy4EsVhwBUEQChZ4ZmSkpFB6crLPBa7RrMW6LbiZSaYKlyxpOAbXiAUX7QhruFhwBVMJXJTxWbduXY7fJ0+enO3vhx56iD+OcDbt//7v//gjCILnLbiRkb4TuHAjhvUWGLXgBgUFetyCq61pq1dwq2PQa/EVBEEQ8gmwbsbF8ddQP4rBtVlw9bgDZ1pwo6pVM7Ruoy7TEMS8TxKDK9ghBRgFQfAzC24AW2+BXoGI2r361u2OBZfo+nWr4Dbiooy6uWLBFQRBKFioBEx4eIQULerT/chIS9MvKJUFV4eL8o0kmTJSJggJpnifJAZXsEMEriAIuoHl0fcxuNb/g4ICKCQk0JAFNzdUkiljMbhWC25YWJBt+dyXscYQSx1cQRCEAgYSMEH8hYf7pNSejcxtG47B1SMm1TEaTDJl1GUaMcT4PyjUd+8kgjkRgSsIgt8lmVLWUr0vB3oFrlpffHyKIQuukYRXajuSRVkQBKHgYdS66c39AF7Jooz43vh4/WWQ3MyizDG7hQr5dqBAMCUicAVB0I3VWpnq8yRTwIigVEmm9K4bGLPgGounFQuuIAhCASUzuZOvBa5RC66ROrhqXndclI24TLMglvhbwQEicAVB0I0SgL604Co3YCPuvUYtuMCIBRcxwUYtuJJFWRAEoeChnjO6rZve2g/lcqxXIKI+n4EYXGDURRkxwUYEN2JwJYOy4AgRuIIg6EY9tHydZAoYsZg+8UQr6t+/vo51Z303kkXZqODGdiC6JYuyYGb++usvatmyJYWFhdGzzz7r690RhPyBUfFnEhdlzBdZtSpFVa+uZ+XGLLiZYtvI/rAFV2rgCmYsEyQIgn9hBguu2gckddJLt241+JMb2iRR+mvaGhfcahnJoiyYmdq1a9MPP/xAs2fPpvj4eF/vjiDkCwxbN723I7otsiAwOJgeP37ckGA16qIMvFGXVyh4iAVXEAS/tOCGhXl+fE77kNWbtMKdmGB3rL6CkNfUqVOHmjZtSsHB0k8FwWOYROBaMjIMCVy3RHx4uN4FbF8NZ3WWGFzBASJwBUEwLMyKFtUv5ry1D6Gh+i243iTLgmvMRRmIBVcQBKFgoYSZL2vggoxUa/12r5TYUXHGOo/RHQuuzcVaLLiCA2RYVhAE3ahnkC9jR91xUTYKauwa3R+jSaaAxOAKvuSWW26hQ4cOOZy2bds2qly5su51jRs3jj+K2NhYWrx48Q3vY1JSkkfWUxCQtvKPtorduZP/P33+vE/7dkJcHP+/8p9/KMiJqHS3nc6fP8//b9i6lQrHxuY6vyU9q9LB0hUrdHlQqXa8mpBginuEXH/maicRuIIgeNVa6U8uygojllX3YnCNb0cQPM26des8tq6RI0fyR1GpUiXq2bPnDa8XL0KeWE9BQNrKP9pqf2wsnSKimvXqUUcf9u0jgYEEG27PO+6goJAQj7bTbxMn0jUi6tS9OxWvVUuXu/TuzO+9evXStY39V65wO5atWNEU9wi5/szVTuKiLAiCX1pwvemibOT4lMt0kSLuiGIRuIIgCAUKg9mLve2ijORRHiezpJDRhFH+2I6CORGBKwiCn1pwg0xiwbX+Hx6uP45JLLiCP7B8+XK2xML1+Pvvv+fvv//+u693SxD8GqPlebxFekpKtv3xJCjfYyhhVOY+GBLbkkVZcIGYDwRBMIwvLbh5kWTKHRflokWNCFyJwRXMz6233krR0dG+3g1ByF+YzILrDZTADdYpcBVGEm+p52iIWHAFB4gFVxAE3SQnp5nAgktet+C6kxHZSGZpd5YRBEEQ/B+zCLN0bwrcxES3MjQbEsRqoMDH2agFcyICVxAE3SQlpfk8OZKtvp4fW3Czyi15oTyDIAiCYPoyQUG+Lm+TGSfrDdIzLbhG3Z/1ujSbqdySYE5E4AqCoJvkZGsqf0kydaMWXJWYSiy4giAIBQqTuCh7E2XBNYqRNrFZwg26QQsFAxG4giAYdlFWFkhfoLYdEmIOC6471lhL5si5uCgLgiAULMySZMqbqBhco7jjoiwWXMERInAFQTDsouxLbKO2IYEmc1EOMdyOYsEVBEEoYIjA9YyLslhwBReIwBUEwc8Ebl7UwXUnyZR+C25iorUdJQZXEAShYGGWJFOmdFEWC67gIUTgCoLgZwLXXC7K7lhwExJSvZ4JWhAEQTAhBcCCq5JM5YkFV5JMCQ4QgSsIgp8JXP+34CqBazTDpCAIguDfmCaLshdJT0lxazm3ygRJkinBASJwBUEwnEXZl2QlmfLfGNzERO/VHxQEQRDMT3624LqLIbdtseAKLhCBKwiC4SzKvsRsLsqqTcLDjVtwBUEQhIKFsm6KwM2JEWusJJkSTCtwDx06RG3btqU6depQ69atac+ePQ7n27VrF3Xu3Jnq16/Pn3nz5uma9v3331Pt2rWpZs2a9Nhjj1FqqrxUCsKNUHBclI3H07qTZEoQBEEoWKj4VBG4OTEST6tcvSUGVzCdwB02bBg9/vjjdPDgQXr55ZdpyJAhOeZJSEigPn360OjRo2nfvn20e/du6tChQ67Tjh07Rm+88Qb9888/dPjwYTp37hxNnDgxz49REPITZnBRNluZIHcSRomLsiAIQsFE1YjNz1mU3cVIkqmMNOtAsQhcwVQC9/z587R582Z68MEH+e8BAwbQqVOnWIxqmTFjBt18883Uvn17/jsoKIhKly6d67Q5c+ZQ7969qVy5cvxC/MQTT9DMmTPz+CgFQfBeDK45kky5kzBKXJQFQRAKtsBVFkhfEhii31vJbC7KqQkJhpcRCg763+I8DMRs+fLlKTg42PZyWKVKFTp58iTVqlXLNt/evXspLCyM7rzzToqOjqYmTZrQ2LFjWci6mob1VK1a1baeatWq8W/2jBs3jj+K2NhYWrx4sUeOMSkpyWPryu9IW/lXO/lyHxISrFbkPXt20eLFZzzeVm3aFKNixc7pXnbbNus+GNmWclE2w7k0S5/yB6StBEHwVQkdfxK4nceNo7BixbxqwVW1do0sIxQcfCZw9ZKWlkbLli2j9evXU4UKFWjUqFH05JNPsoXW1TS9jBw5kj+KSpUqUc+ePT2y73hp9NS68jvSVv7STuv5X1/uQ3w8EnRsojZtWlDPnvU83lZGl2ncOI6KFPnP4HK+b0fz9Cn/QdpKEIQbJS052TSNGBSqP3eEEVo995zhZZo++STV6tdP9/xpmRbcwExDmSBo8Zl/ROXKlSkmJoZFKrBYLGxhhRVXC/7u0qULVaxYka28cGmGoNUz7cSJE7b1HD9+PMe6BUHwP/IiyZQRKlSIoM8/7+Xr3RAEQRD8gGAT1b/1lsB1h+7ffktFSpUybMEVBFMJ3DJlylCLFi1o+vTp/PfcuXPZeqp1Twb33HMPbdq0ia5du8Z/L1y4kJo2bZrrNMT0/v7773T27FkWz+PHj6dBgwbl8VEKQv7i5Mln6dQp4yOz/lYmSBAEQRC8QbPhw+nBTZtM0bhmi8E1gorBFQRH+NSuP2HCBM6c/MEHH1BkZCRNmTKFfx86dCgniMIHVle4HqOcUGBgIFtrVTZkV9Nq1KhB77zzDrVr147/RikhZG0WBMF9KleOMlGSKd8n6HCX2bPvtlmiBUEQhIJDUEgIlWvVisyAPwvcRkOGUPLVq77eDcGk+FTg1q1bl9atW5fj98mTJ2f7+6GHHuKPI1xNQ+1bfARByD8oYejPFtyBAxv4ehcEQRCEAg7Etr8SUakSdR4zxte7IZgU/zWBCIJQIFEuymaJwRUEQRAEfyTQRDG4guBJJPWYIAh+RVCQVeBWq2a8BIEgCIIgCESVOnSgupKbRsiniMAVBMGvCAoKJIvlLV/vhiAIgiD4LYPWrPH1LgiC1xAXZUEQBEEQBEEQBCFfIAJXEARBEARBEARByBeIwBUEQRAEQRAEQRDyBSJwBUEQBEEQBEEQhHyBCFxBEARBEARBEAQhXyACVxAEQRAEQRAEQcgXiMAVBEEQBEEQBEEQ8gUBFovF4uudMBNhYWFUunRpj6wrPj6ewsPDPbKu/I60lbST9Cm59grKferChQuUnJxM+RlPPUvl2SBt5Q2kX0k7SZ/K389REbhepFKlShQdHe3NTeQbpK2knaRPybVnduQ+JW1uZqR/SltJn5Lrz+xUyiNtJC7KgiAIgiAIgiAIQr5ABK4gCIIgCIIgCIKQLxCB60VGjhzpzdXnK6StpJ2kT8m1Z3bkPiVtbmakf0pbSZ+S68/sjMwjbSQxuIIgCIIgCIIgCEK+QCy4giAIgiAIgiAIQr5ABK4gCIIgCIIgCIKQLxCBe4McOnSI2rZtS3Xq1KHWrVvTnj17HM73/fffU+3atalmzZr02GOPUWpqKhU09LTV8ePHqXPnzhQVFUXNmjWjgoiedlqxYgW1adOGGjRoQA0bNqSXXnqJMjIyqKChp63WrVvHfQkftNWwYcPyfQ1Sd+9TAKXRu3btSsWKFaOCiJ62WrVqFRUuXNjWr/BJTEz0yf7mB+Q56tm2kueoPEc9ff3Jc1Seo373HLUIN0SXLl0sU6ZM4e+zZ8+2tGrVKsc8R48etZQvX94SExNjycjIsNx1112Wr7/+usC1vJ62unTpkuWff/6x/Pnnn5amTZtaCiJ62mnr1q2WI0eO8PfExERLu3btbMsUJPS01fXr1y0pKSn8PT093dK3b1/LuHHjLAUJPe2kGDt2rGXo0KGWqKgoS0FET1utXLmywN6fvIE8Rz3bVvIcleeop68/eY7Kc9TfnqMicG+Ac+fOWSIiIiypqan8N8Rr2bJlLYcOHco23yeffGIZNmyY7e+//vqLBUlBQm9bFfQXSKPtpBgxYoTlrbfeshQk3GkrDAb07NnT8tlnn1kKCkbaaffu3ZYOHTpYDh8+XCAFrt62Kqj3J28gz1HPt1VB76fyHPVuW8lzVJ6j/vAcFRflG+DUqVNUvnx5Cg4O5r8DAgKoSpUqdPLkyWzz4e+qVava/q5WrVqOefI7etuqoONOO509e5bmzJlDd955JxUkjLQVXPaaNm1KpUqVYvf34cOHU0FBbzshbALhExMmTKCgoCAqiBjpU0eOHKEWLVqw+9W3337rg73NH8hz1PNtVdCR56h32kqeo/Ic9afnqAhcQfBjrl27RnfddRfH4LZq1crXu2NaMKi0Y8cOHgxA/O28efN8vUum45133qH+/ftT/fr1fb0rpgcP5OjoaNq6dSvNnz+fxo8fT7/++quvd0sQBDeQ56g+5DmaO/IcNc9zVATuDVC5cmWKiYmhtLQ0/hsu3xihwEiFFvx94sSJbKNg9vPkd/S2VUHHSDvFxcVRr169qE+fPnlWONvf+1R4eDgNGjSIfv75Zyoo6G2n1atX01dffcUvMe3bt+eXPny/cOECFRT0tlVkZCR7AoBKlSrRfffdR//8849P9tnfkeeo59uqoCPPUe+0lUKeo/Ic9YfnqAjcG6BMmTI8AjF9+nT+e+7cuXySatWqlW2+AQMG0O+//87WI5xojFLgJbsgobetCjp62yk+Pp7FLT6vv/46FUT0ttXhw4dtWctTUlJ4pLBJkyZUUNDbTniwYCAOA3D//vsvP3zwvXTp0lRQ0NtWeHirrOUYaPrzzz+pefPmPtlnf0eeo55vq4KOPEc931byHJXnqN89R70W3VtA2L9/v+Xmm2+21K5d29KyZUvLzp07+fdHH33U8ttvv9nmmzhxoqVGjRr8+d///mfL6lqQ0NNWyNRXsWJFS6lSpSwhISH8/ZVXXrEUJPS00+jRoy3BwcEcoK8++K2goaetJkyYYGnYsKGlSZMmlgYNGlieeuopTpJRkNB7n1IcO3asQCaZ0ttWX331Ffcl1aeQ4A2JNATvtTmQ56g8Rz3Zp+Q5qr+t5Dkqz1F/e44G4B/PyWVBEARBEARBEARB8A3ioiwIgiAIgiAIgiDkC0TgCoIgCIIgCIIgCPkCEbiCIAiCIAiCIAhCvkAEriAIgiAIgiAIgpAvEIErCIIgCIIgCIIg5AtE4AqCIAiCIAiCIAj5AhG4giAIgiAIgiAIQr5ABK4g+Cnz5s2jli1bUrNmzahevXrUtWtXysjI4GkBAQEUGxtraH1vv/02JSUlGZqObcfFxZG3wHE0btyYFi5c6HK+Ll26UIkSJejzzz/32r4IgiAI+Qt5jmYhz1EhPxFgsVgsvt4JQRCMERMTw8Jvy5YtVLVqVf5t69at1Lx5cxaF+Fy5coWKFSume525LePOOm8UI9scMmQIC+5nn302T/ZNEARB8F/kOZoTeY4K+QWx4AqCH3Lu3DkKCgpiq6WiRYsWLAgV3377LbVp04aqV69OU6ZMsf2+ePFinrdJkybUqVMn2rt3Lz3xxBM8rUOHDiwSz58/n217zqZrLcX4/v7779NNN91E1apVowULFtCHH35IrVq1otq1a9OqVats69u0aRNbnDENonz27Nm6jnv58uXUtm1b3v86derQ1KlT3WxBQRAEoSAjz1F5jgr5GFhwBUHwL9LT0y39+/e3FC9e3NK3b1/LJ598YomOjrZNx6X96aef8vd9+/ZZwsPDLampqZZz585ZSpQoYdm5cydPmz59uqV+/fqWjIwMXubKlStOt+louvY3fP/888/5+7JlyyxFixa1TJkyhf/+9ddfLa1ateLvmL9Zs2aWM2fO8N8XLlywVK5cOdv+O1o/9rFMmTK25dAG2v15+OGHLZ999pmbLSoIgiAUJOQ5Ks9RIf8iFlxB8EMCAwNp7ty5tHbtWurVqxf9999/1LBhQzp8+LBtngceeID/R3xucHAwnT17ljZs2MCuzfioec6cOUOnT5/2yH7de++9/D8ss9evX6dBgwbx37AkHzp0iL9jn48ePUq33XYbW4O7devGvx84cCDX9ZcrV47+7//+j+bMmcPxwHnpLi0IgiDkH+Q5Ks9RIf8S7OsdEATBfSBe8Rk2bBgL3d9//51GjhzJ0woVKmSbD+7MaWlpXm9qtU1sz/5vtX0YZiHGIXSNABfozZs30+rVq+nXX3+l559/nkVzaGiox49DEARBKBjIc1Seo0L+Qyy4guCHwOIKq60CiZiOHTtGNWvWdLnczTffTLt27aLdu3fz37NmzaKKFSvyJyIigq5evep02dym6wUxtNjXZcuW2X7bvn07paSkuFxu//79LJRh8X311VcpMTHRJqQFQRAEwQjyHJXnqJB/EQuuIPghsIa+++67LBSLFCnCfz/88MPUp08fl8uVLl2afv75Zxo8eDAvU7x4cU7wBOsoLKLdu3fn9S1ZsoTKlCmTbdncpusF2/zrr7/ohRde4HWmpqZSlSpVOCmVKz777DNauXIlFS1alPcBVlwRuIIgCII7yHNUnqNC/kXKBAmCYFqkTJAgCIIgyHNUEIwgLsqCIJiWsmXLcimjhQsX5lqgHrG5sO4KgiAIgiDPUaHgIhZcQRAEQRAEQRAEIV8gFlxBEARBEARBEAQhXyACVxAEQRAEQRAEQcgXiMAVBEEQBEEQBEEQ8gUicAVBEARBEARBEIR8gQhcQRAEQRAEQRAEIV8gAlcQBEEQBEEQBEHIF4jAFQRBEARBEARBEPIFInAFQRAEQRAEQRCEfIEIXEEQBEEQBEEQBIHyA/8PRLgPcMcK6n8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Maximum |beta_p target deviation| = 5.54%\n",
+      "Maximum |li target deviation|     = 2.33%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PROFILE TARGET EVOLUTION\n",
+    "from io import BytesIO\n",
+    "from IPython.display import Image, display\n",
+    "\n",
+    "fig, axes = plt.subplots(\n",
+    "    nrows=2,\n",
+    "    ncols=2,\n",
+    "    figsize=(12, 6),\n",
+    "    dpi=80,\n",
+    "    sharex=\"col\",\n",
+    ")\n",
+    "\n",
+    "axes[0, 0].plot(times, dynamic_betap, color=\"navy\", linewidth=1, label=\"FreeGSNKE\")\n",
+    "axes[0, 0].plot(times, profile_betap_target, color=\"k\", linestyle=\"--\", linewidth=1.5, label=\"constant target\")\n",
+    "axes[0, 0].set_ylabel(r\"$\\beta_p$\")\n",
+    "axes[0, 0].grid()\n",
+    "axes[0, 0].legend()\n",
+    "\n",
+    "axes[1, 0].plot(times, dynamic_li, color=\"navy\", linewidth=1, label=\"FreeGSNKE\")\n",
+    "axes[1, 0].plot(times, profile_li_target, color=\"k\", linestyle=\"--\", linewidth=1.5, label=\"constant target\")\n",
+    "axes[1, 0].set_xlabel(r\"Shot time [$s$]\")\n",
+    "axes[1, 0].set_ylabel(r\"$l_i$\")\n",
+    "axes[1, 0].grid()\n",
+    "axes[1, 0].legend()\n",
+    "\n",
+    "betap_percent_error = 100 * (dynamic_betap - profile_betap_target) / profile_betap_target\n",
+    "li_percent_error = 100 * (dynamic_li - profile_li_target) / profile_li_target\n",
+    "\n",
+    "axes[0, 1].plot(times, betap_percent_error, color=\"darkred\", linewidth=1)\n",
+    "axes[0, 1].axhline(0.0, color=\"k\", linestyle=\"--\", linewidth=1)\n",
+    "axes[0, 1].set_ylabel(r\"$\\beta_p$ deviation [%]\")\n",
+    "axes[0, 1].grid()\n",
+    "\n",
+    "axes[1, 1].plot(times, li_percent_error, color=\"darkred\", linewidth=1)\n",
+    "axes[1, 1].axhline(0.0, color=\"k\", linestyle=\"--\", linewidth=1)\n",
+    "axes[1, 1].set_xlabel(r\"Shot time [$s$]\")\n",
+    "axes[1, 1].set_ylabel(r\"$l_i$ deviation [%]\")\n",
+    "axes[1, 1].grid()\n",
+    "\n",
+    "fig.suptitle(r\"Constant Physical Profile Targets\", y=0.98)\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "plot_buffer = BytesIO()\n",
+    "fig.savefig(plot_buffer, format=\"png\", bbox_inches=\"tight\")\n",
+    "display(Image(data=plot_buffer.getvalue()))\n",
+    "plt.close(fig)\n",
+    "\n",
+    "print(f\"Maximum |beta_p target deviation| = {np.max(np.abs(betap_percent_error)):.3g}%\")\n",
+    "print(f\"Maximum |li target deviation|     = {np.max(np.abs(li_percent_error)):.3g}%\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:54.793618Z",
+     "iopub.status.busy": "2026-06-21T18:16:54.793517Z",
+     "iopub.status.idle": "2026-06-21T18:16:54.817788Z",
+     "shell.execute_reply": "2026-06-21T18:16:54.817541Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/607465510.py:61: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PLASMA CURRENT EVOLUTION\n",
+    "\n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=1,\n",
+    "    ncols=1,\n",
+    "    figsize=(8, 4),\n",
+    "    dpi=80\n",
+    ")\n",
+    "\n",
+    "# --- references and masks ---\n",
+    "FB_reference = PCS.PlasmaController.interpolants['ip_ref'](times)\n",
+    "FF_reference = PCS.PlasmaController.interpolants['vloop_ff'](times)\n",
+    "\n",
+    "blend = PCS.PlasmaController.interpolants['ip_blend'](times)\n",
+    "\n",
+    "FB_mask = (blend > 0) & (np.abs(FB_reference) > 0)\n",
+    "FF_mask = (blend < 1) & (np.abs(FF_reference) > 0)\n",
+    "\n",
+    "# --- shade FB regions (green) ---\n",
+    "on_regions = np.where(np.diff(FB_mask.astype(int)) != 0)[0] + 1\n",
+    "for seg_t, seg_state in zip(np.split(times, on_regions),\n",
+    "                            np.split(FB_mask, on_regions)):\n",
+    "    if np.all(seg_state):\n",
+    "        ax.axvspan(seg_t[0], seg_t[-1],\n",
+    "                   color='green', alpha=0.25,\n",
+    "                   label=\"FB active\")\n",
+    "\n",
+    "# --- shade FF regions (yellow) ---\n",
+    "on_regions = np.where(np.diff(FF_mask.astype(int)) != 0)[0] + 1\n",
+    "for seg_t, seg_state in zip(np.split(times, on_regions),\n",
+    "                            np.split(FF_mask, on_regions)):\n",
+    "    if np.all(seg_state):\n",
+    "        ax.axvspan(seg_t[0], seg_t[-1],\n",
+    "                   color='gold', alpha=0.25,\n",
+    "                   label=\"FF active\")\n",
+    "\n",
+    "# --- FreeGSNKE ---\n",
+    "ax.plot(times, dynamic_ip,\n",
+    "        color='navy', linewidth=1,\n",
+    "        marker='x', markersize=0,\n",
+    "        label=\"FreeGSNKE\")\n",
+    "\n",
+    "# --- FB reference ---\n",
+    "ax.plot(times[FB_mask], FB_reference[FB_mask],\n",
+    "        color='k', linestyle='--',\n",
+    "        linewidth=1.5,\n",
+    "        label=\"FB reference\")\n",
+    "\n",
+    "ax.set_xlabel(r\"Shot time [$s$]\")\n",
+    "ax.set_ylabel(\"Plasma current [A]\")\n",
+    "ax.grid()\n",
+    "\n",
+    "# deduplicate legend entries\n",
+    "handles, labels = ax.get_legend_handles_labels()\n",
+    "ax.legend(dict(zip(labels, handles)).values(),\n",
+    "          dict(zip(labels, handles)).keys())\n",
+    "\n",
+    "ax.set_ylim([7.54e5, 7.64e5])\n",
+    "fig.suptitle(\"Plasma Current\", y=0.98)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:54.819353Z",
+     "iopub.status.busy": "2026-06-21T18:16:54.819255Z",
+     "iopub.status.idle": "2026-06-21T18:16:54.842054Z",
+     "shell.execute_reply": "2026-06-21T18:16:54.841780Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/1832711078.py:37: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PLASMA VERTICAL POSITION EVOLUTION\n",
+    "\n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=1,\n",
+    "    ncols=1,\n",
+    "    figsize=(8, 4),\n",
+    "    dpi=80\n",
+    ")\n",
+    "\n",
+    "# --- FB reference ---\n",
+    "FB_reference = PCS.VerticalController.interpolants['z_ref'](times)\n",
+    "\n",
+    "# --- shade FB-active region (always on here) ---\n",
+    "ax.axvspan(times[0], times[-1],\n",
+    "           color='green', alpha=0.2,\n",
+    "           label=\"FB active\")\n",
+    "\n",
+    "# --- references ---\n",
+    "ax.plot(times, FB_reference,\n",
+    "        color='k', linestyle='--',\n",
+    "        linewidth=1.5,\n",
+    "        label=\"FB reference\")\n",
+    "\n",
+    "# --- FreeGSNKE ---\n",
+    "ax.plot(times, z_current,\n",
+    "        color='navy', linewidth=1,\n",
+    "        marker='x', markersize=0,\n",
+    "        label=\"FreeGSNKE\")\n",
+    "\n",
+    "ax.set_xlabel(r\"Shot time [$s$]\")\n",
+    "ax.set_ylabel(\"Vertical position [m]\")\n",
+    "ax.grid()\n",
+    "ax.legend()\n",
+    "\n",
+    "fig.suptitle(\"Vertical Position\", y=0.98)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:54.843445Z",
+     "iopub.status.busy": "2026-06-21T18:16:54.843358Z",
+     "iopub.status.idle": "2026-06-21T18:16:54.905749Z",
+     "shell.execute_reply": "2026-06-21T18:16:54.905501Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/3685405346.py:76: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SHAPE PARAMETER EVOLUTION\n",
+    "# the ramp down in Rx here is designed to show how one might increase triangularity of the plasma (see next plot for this effect)\n",
+    "\n",
+    "ntarg = len(ctrl_targets)\n",
+    "\n",
+    "fig, axes = plt.subplots(\n",
+    "    nrows=ntarg,\n",
+    "    ncols=1,\n",
+    "    figsize=(8, 12),\n",
+    "    dpi=80,\n",
+    "    sharex=True\n",
+    ")\n",
+    "\n",
+    "for j, targ in enumerate(ctrl_targets):\n",
+    "    ax = axes[j]\n",
+    "\n",
+    "    # --- references and masks ---\n",
+    "    FF_reference = PCS.ShapeController.interpolants[targ]['ff'](times)\n",
+    "    FB_reference = PCS.ShapeController.interpolants[targ]['ref'](times)\n",
+    "\n",
+    "    FF_mask = (\n",
+    "        (PCS.ShapeController.interpolants[targ]['blend'](times) < 1)\n",
+    "        & (np.abs(PCS.ShapeController.interpolants[targ]['ff'].derivative()(times)) > 0)\n",
+    "    )\n",
+    "\n",
+    "    FB_mask = (\n",
+    "        (PCS.ShapeController.interpolants[targ]['blend'](times) > 0)\n",
+    "        & (np.abs(FB_reference) > 0)\n",
+    "    )\n",
+    "\n",
+    "    # --- shade FB regions (green) ---\n",
+    "    on_regions = np.where(np.diff(FB_mask.astype(int)) != 0)[0] + 1\n",
+    "    for seg_t, seg_state in zip(np.split(times, on_regions),\n",
+    "                                np.split(FB_mask, on_regions)):\n",
+    "        if np.all(seg_state):\n",
+    "            ax.axvspan(seg_t[0], seg_t[-1], color='green', alpha=0.25,\n",
+    "                       label=\"FB active\" if j == 0 else None)\n",
+    "\n",
+    "    # --- shade FF regions (yellow) ---\n",
+    "    on_regions = np.where(np.diff(FF_mask.astype(int)) != 0)[0] + 1\n",
+    "    for seg_t, seg_state in zip(np.split(times, on_regions),\n",
+    "                                np.split(FF_mask, on_regions)):\n",
+    "        if np.all(seg_state):\n",
+    "            ax.axvspan(seg_t[0], seg_t[-1], color='gold', alpha=0.25,\n",
+    "                       label=\"FF active\" if j == 0 else None)\n",
+    "\n",
+    "    # --- references ---\n",
+    "    ax.plot(times[FB_mask], FB_reference[FB_mask],\n",
+    "            color='k', linestyle='--', linewidth=1.5,\n",
+    "            label=\"FB reference\" if j == 0 else None)\n",
+    "\n",
+    "    if np.any(FF_mask):\n",
+    "        offset = interpolants[targ + '_meas'](times[FF_mask][0])\n",
+    "        ax.plot(times[FF_mask], FF_reference[FF_mask] + offset,\n",
+    "                color='r', linestyle='--', linewidth=1.5,\n",
+    "                label=\"FF reference\" if j == 0 else None)\n",
+    "\n",
+    "    # --- FreeGSNKE ---\n",
+    "    ax.plot(times, dynamic_shape_targets[j, :],\n",
+    "            color='navy', linewidth=1,\n",
+    "            marker='x', markersize=0,\n",
+    "            label=\"FreeGSNKE\" if j == 0 else None)\n",
+    "\n",
+    "    ax.set_ylabel(f\"{ctrl_targets[j]} [m]\")\n",
+    "    ax.grid()\n",
+    "    ax.set_ylim([np.min(FB_reference)-0.02, np.max(FB_reference)+0.02])\n",
+    "\n",
+    "# shared x label\n",
+    "axes[-1].set_xlabel(r\"Shot time [$s$]\")\n",
+    "\n",
+    "# legend once\n",
+    "axes[0].legend(ncol=4, loc=\"upper right\")\n",
+    "\n",
+    "fig.suptitle(\"Shape parameters\", y=0.995, fontsize=14)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:54.907057Z",
+     "iopub.status.busy": "2026-06-21T18:16:54.906970Z",
+     "iopub.status.idle": "2026-06-21T18:16:54.927597Z",
+     "shell.execute_reply": "2026-06-21T18:16:54.927301Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/3380605802.py:22: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PLASMA TRIANGULARITY EVOLUTION \n",
+    "\n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=1,\n",
+    "    ncols=1,\n",
+    "    figsize=(8, 4),\n",
+    "    dpi=80\n",
+    ")\n",
+    "\n",
+    "# --- FreeGSNKE ---\n",
+    "ax.plot(times[0:-1], dynamic_triangularity[0:-1],\n",
+    "        color='navy', linewidth=1,\n",
+    "        marker='x', markersize=0,\n",
+    "        label=\"FreeGSNKE\")\n",
+    "\n",
+    "ax.set_xlabel(r\"Shot time [$s$]\")\n",
+    "ax.set_ylabel(\"Triangularity\")\n",
+    "ax.grid()\n",
+    "ax.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also show the voltages produced by the PCS and the subsequent evolution of the currents for each of the PF coils. To display the voltage/current limits, uncomment the relevant sections in the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:54.929047Z",
+     "iopub.status.busy": "2026-06-21T18:16:54.928962Z",
+     "iopub.status.idle": "2026-06-21T18:16:55.301719Z",
+     "shell.execute_reply": "2026-06-21T18:16:55.301416Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/_y/dm0w4q1j76scm_xhwnz9bsz80000gp/T/ipykernel_29855/248696776.py:65: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PF COIL VOLTAGES AND CURRENTS\n",
+    "\n",
+    "ncoils = len(active_coils)\n",
+    "\n",
+    "fig, axes = plt.subplots(\n",
+    "    nrows=ncoils,\n",
+    "    ncols=2,\n",
+    "    figsize=(18, 45),\n",
+    "    dpi=80,\n",
+    "    sharex=True\n",
+    ")\n",
+    "\n",
+    "for j, coil in enumerate(active_coils):\n",
+    "    axV = axes[j, 0]  # voltage column\n",
+    "    axI = axes[j, 1]  # current column\n",
+    "\n",
+    "    # VOLTAGES (left)\n",
+    "\n",
+    "    # # voltage limits\n",
+    "    # if coil not in [\"P6\"]:\n",
+    "    #     vlim = PCS.PFController.data['coil_voltage_lims']['vals'][0][j]\n",
+    "    #     axV.hlines([-vlim, vlim], times[0], times[-1],\n",
+    "    #                colors='k', linestyles='--', linewidth=1.2,\n",
+    "    #                label=\"Coil limits\" if j == 0 else None)\n",
+    "\n",
+    "    axV.plot(times[0:-1], V_approved[j, 0:-1],\n",
+    "             color='navy', linewidth=1,\n",
+    "             marker='x', markersize=0,\n",
+    "             label=\"FreeGSNKE\")\n",
+    "\n",
+    "    axV.set_ylabel(f'{coil} voltage [V]')\n",
+    "    axV.grid()\n",
+    "    if j == 0:\n",
+    "        axV.legend()\n",
+    "\n",
+    "    # CURRENTS (right)\n",
+    "\n",
+    "    # # current limits\n",
+    "    # if coil not in [\"P6\"]:\n",
+    "    #     imin = PCS.SystemsController.data['min_coil_curr_lims']['vals'][0][j]\n",
+    "    #     imax = PCS.SystemsController.data['max_coil_curr_lims']['vals'][0][j]\n",
+    "    #     axI.hlines([imin, imax], times[0], times[-1],\n",
+    "    #                colors='k', linestyles='--', linewidth=1.2,\n",
+    "    #                label=\"Coil limits\" if j == 0 else None)\n",
+    "\n",
+    "    axI.plot(times, dynamic_currents[j, :],\n",
+    "             color='navy', linewidth=1,\n",
+    "             marker='x', markersize=0,\n",
+    "             label=\"FreeGSNKE\")\n",
+    "\n",
+    "    axI.set_ylabel(f'{coil} current [A]')\n",
+    "    axI.grid()\n",
+    "    if j == 0:\n",
+    "        axI.legend()\n",
+    "\n",
+    "# x-labels only on bottom row\n",
+    "axes[-1, 0].set_xlabel(r'Shot time [$s$]')\n",
+    "axes[-1, 1].set_xlabel(r'Shot time [$s$]')\n",
+    "\n",
+    "# column titles\n",
+    "axes[0, 0].set_title(\"PF Coil Voltages\")\n",
+    "axes[0, 1].set_title(\"PF Coil Currents\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cell can be uncommented to make an animation of the equilibrium in the machine over time. Might take a few seconds to run and will save the output .mp4 in the `data` directory. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-21T18:16:55.303428Z",
+     "iopub.status.busy": "2026-06-21T18:16:55.303305Z",
+     "iopub.status.idle": "2026-06-21T18:16:55.305784Z",
+     "shell.execute_reply": "2026-06-21T18:16:55.305543Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# # SAVE AN ANIMATION OF THE SIMULATION\n",
+    "# %matplotlib inline\n",
+    "\n",
+    "# import matplotlib.animation as animation\n",
+    "\n",
+    "# plt.rcParams['figure.dpi'] = 90\n",
+    "\n",
+    "# fig1, ax1 = plt.subplots(1, 1, figsize=(8, 8))\n",
+    "\n",
+    "# # Plot static wall / tokamak background\n",
+    "# eq.tokamak.plot(axis=ax1, show=False)\n",
+    "# ax1.plot(tokamak.wall.R, tokamak.wall.Z, color='k', linewidth=1.2)\n",
+    "# ax1.grid(True, which='both', alpha=0.5)\n",
+    "# ax1.set_aspect('equal')\n",
+    "# ax1.set_xlabel(r'Major radius, $R$ $[m]$')\n",
+    "# ax1.set_ylabel(r'Height, $Z$ $[m]$')\n",
+    "# ax1.set_xlim(0.05, 2.15)\n",
+    "# ax1.set_ylim(-2.25, 2.25)\n",
+    "\n",
+    "# # Determine contour levels from entire dynamic_psi\n",
+    "# min_psi = np.min(dynamic_psi)\n",
+    "# max_psi = np.max(dynamic_psi)\n",
+    "# levels = np.linspace(min_psi, max_psi, 40)\n",
+    "\n",
+    "# # --- Storage for dynamic artists ---\n",
+    "# contour_artists = []\n",
+    "# scatter_artists = []\n",
+    "\n",
+    "# # --- Update function ---\n",
+    "# def update(i):\n",
+    "    \n",
+    "#     global contour_artists, scatter_artists\n",
+    "\n",
+    "#     # Remove previous dynamic artists\n",
+    "#     for c in contour_artists + scatter_artists:\n",
+    "#         if isinstance(c, list):\n",
+    "#             for coll in c:\n",
+    "#                 coll.remove()\n",
+    "#         else:\n",
+    "#             c.remove()\n",
+    "#     contour_artists = []\n",
+    "#     scatter_artists = []\n",
+    "\n",
+    "#     ax1.set_title(rf\"$t$ = {np.round(times[i],3)}\")\n",
+    "\n",
+    "#     # Main psi contours\n",
+    "#     c1 = ax1.contour(eq.R, eq.Z, dynamic_psi[:,:,i], levels=levels, alpha=0.8, cmap='viridis')\n",
+    "#     contour_artists.append(c1)\n",
+    "\n",
+    "#     # plasma boundary\n",
+    "#     c2 = ax1.contour(eq.R, eq.Z, dynamic_psi[:,:,i],\n",
+    "#                          levels=[dynamic_psi_boundary[i]],\n",
+    "#                          linestyles=\"-\", colors='r', linewidths=1.4)\n",
+    "#     contour_artists.append(c2)\n",
+    "\n",
+    "#     # adds separatrix of primary X-point if plasma limited\n",
+    "#     if dynamic_limiter_flag[i]:\n",
+    "#         c3 = ax1.contour(eq.R, eq.Z, dynamic_psi[:,:,i],\n",
+    "#                             levels=[dynamic_xpts[i][0,2]],\n",
+    "#                             linestyles=\"--\", colors='k', linewidths=1.4)\n",
+    "#         contour_artists.append(c3)\n",
+    "\n",
+    "\n",
+    "#     # X-points and O-points\n",
+    "#     sc1 = ax1.scatter(dynamic_xpts[i][:,0], dynamic_xpts[i][:,1], color='r', marker='x', s=30)\n",
+    "#     sc2 = ax1.scatter(dynamic_opts[i][:,0], dynamic_opts[i][:,1], color='g', marker='2', s=30)\n",
+    "\n",
+    "#     # indicate which is the primary X-point more clearly\n",
+    "#     sc3 = ax1.scatter(dynamic_xpts[i][0,0], dynamic_xpts[i][0,1], color='r', marker='x', s=60)\n",
+    "\n",
+    "#     scatter_artists.extend([sc1, sc2, sc3])\n",
+    "\n",
+    "#     return contour_artists + scatter_artists\n",
+    "\n",
+    "# # --- Animation ---\n",
+    "# num_frames = len(times)\n",
+    "# frames_to_plot = range(0, num_frames, 5)\n",
+    "# fps = int(len(frames_to_plot)/10)\n",
+    "# ani = animation.FuncAnimation(fig1, update, frames=frames_to_plot, interval=1, blit=True)\n",
+    "\n",
+    "# # save to video (much faster & smaller than GIF)\n",
+    "# ani.save(f\"data/animated_equilibrium.mp4\", writer=\"ffmpeg\", fps=fps)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "freegsnke",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/freegsnke/equilibrium_update.py
+++ b/freegsnke/equilibrium_update.py
@@ -279,9 +279,6 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
             > 1e-5
         )
         if check:
-            print(
-                "Dicrepancy between psi_func and plasma_psi detected. psi_func has been re-set."
-            )
             # redefine interpolating function
             self.psi_func_interp = interpolate.RectBivariateSpline(
                 self.R[:, 0], self.Z[0, :], self.plasma_psi

--- a/freegsnke/jtor_update.py
+++ b/freegsnke/jtor_update.py
@@ -19,16 +19,61 @@ You should have received a copy of the GNU Lesser General Public License
 along with FreeGSNKE.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from dataclasses import dataclass
+
 import freegs4e.jtor
 import numpy as np
 from freegs4e.gradshafranov import mu0
 from matplotlib.path import Path
 from scipy.ndimage import maximum_filter
+from scipy.optimize import least_squares
 from skimage import measure
 
 from . import jtor_refinement
 from . import switch_profile as swp
 from .copying import copy_into
+
+
+@dataclass
+class LaoBetapLiFitResult:
+    """Result returned by :func:`fit_lao85_betap_li_ip`.
+
+    Attributes
+    ----------
+    alpha, beta : ndarray
+        The fitted two-coefficient Lao pressure and FF' vectors supplied to
+        :class:`Lao85` before optional logic coefficients are appended.
+    effective_alpha, effective_beta : ndarray
+        Full coefficient vectors used by the returned profile object after
+        applying ``alpha_logic`` and ``beta_logic``.
+    target_betap, final_betap : float
+        Requested and achieved poloidal beta. This uses ``eq.poloidalBeta1()``,
+        matching the definition used by ``ConstrainBetapIp``.
+    target_li, final_li : float
+        Requested and achieved internal inductance using ``li_method``.
+    metric_jacobian : ndarray or None
+        Physical Jacobian ``d[beta_p, li] / d[alpha0, alpha1, beta0, beta1]``
+        supplied to, or built for, the least-squares optimiser.
+    optimizer_result : scipy.optimize.OptimizeResult
+        Raw optimiser result from ``scipy.optimize.least_squares``.
+    evaluations : list of dict
+        Per-objective-call diagnostics, including failed static solves.
+    """
+
+    alpha: np.ndarray
+    beta: np.ndarray
+    effective_alpha: np.ndarray
+    effective_beta: np.ndarray
+    alpha_logic: bool
+    beta_logic: bool
+    target_betap: float
+    final_betap: float
+    target_li: float
+    final_li: float
+    li_method: str
+    metric_jacobian: object
+    optimizer_result: object
+    evaluations: list
 
 
 class Jtor_universal:
@@ -69,7 +114,8 @@ class Jtor_universal:
         copy_into(self, obj, "limiter_mask_out", mutable=True)
         copy_into(self, obj, "limiter_mask_for_plotting", mutable=True)
         copy_into(self, obj, "edge_mask", mutable=True)
-        obj.inputs = self.inputs[::]  # shallow copy suffices
+        if hasattr(self, "inputs"):
+            obj.inputs = self.inputs[::]  # shallow copy suffices
 
         # *Should* not be necessary to copy this
         obj.limiter_handler = self.limiter_handler
@@ -923,6 +969,340 @@ class Lao85(freegs4e.jtor.Lao85, Jtor_universal):
         )
 
         return pars
+
+
+def fit_lao85_betap_li_ip(
+    eq,
+    static_solver,
+    Ip,
+    fvac,
+    betap,
+    li,
+    alpha=None,
+    beta=None,
+    alpha_logic=True,
+    beta_logic=True,
+    li_method="internalInductance2",
+    Raxis=1,
+    target_relative_tolerance=1e-8,
+    max_solving_iterations=100,
+    solve_kwargs=None,
+    optimizer_kwargs=None,
+    residual_scales=None,
+    regularization_weight=1e-6,
+    coefficient_scales=None,
+    use_metric_jacobian=False,
+    metric_jacobian=None,
+    jacobian_rel_step=1e-4,
+):
+    """Fit a four-coefficient Lao85 profile to static ``Ip``, ``betap`` and ``li``.
+
+    The fitted profile uses two pressure coefficients and two FF' coefficients:
+    ``alpha = [alpha0, alpha1]`` and ``beta = [beta0, beta1]``. These are the
+    coefficients supplied to :class:`Lao85`; when ``alpha_logic`` or
+    ``beta_logic`` is true, :class:`Lao85` appends the usual boundary coefficient
+    so that the corresponding profile vanishes at the plasma edge.
+
+    The total plasma current is enforced through the standard ``Lao85``
+    ``Ip_logic`` global normalisation. The fitted scalar targets are therefore
+    ``betap`` from ``eq.poloidalBeta1()`` and ``li`` from
+    ``getattr(eq, li_method)()``. The default ``li_method`` is
+    ``internalInductance2``.
+
+    Four coefficients are fitted to two scalar targets after the current
+    normalisation has removed one scale direction. A small regularisation term
+    resolves the remaining freedom by favouring coefficients close to the
+    supplied initial ``alpha`` and ``beta`` values.
+
+    Parameters
+    ----------
+    eq : FreeGSNKE equilibrium
+        Equilibrium object to solve. It is updated in-place to the final fitted
+        static equilibrium.
+    static_solver : freegsnke.GSstaticsolver.NKGSsolver
+        Static Grad-Shafranov solver compatible with ``eq``.
+    Ip : float
+        Target total plasma current [A].
+    fvac : float
+        Vacuum toroidal field parameter ``R * B_tor`` [T m].
+    betap : float
+        Target poloidal beta using the ``ConstrainBetapIp`` definition.
+    li : float
+        Target internal inductance using ``li_method``.
+    alpha, beta : array-like of length 2, optional
+        Initial Lao coefficients before optional boundary coefficients are
+        appended.
+    alpha_logic, beta_logic : bool, optional
+        Whether to append the standard Lao boundary coefficient for p' or FF'.
+    li_method : str, optional
+        Name of the equilibrium method used to evaluate internal inductance.
+    target_relative_tolerance : float, optional
+        Static solve tolerance used for each trial profile.
+    max_solving_iterations : int, optional
+        Maximum static solve iterations used for each trial profile.
+    solve_kwargs, optimizer_kwargs : dict, optional
+        Additional keyword arguments forwarded to the static solve and
+        ``scipy.optimize.least_squares`` respectively.
+    residual_scales : sequence of two floats, optional
+        Scaling applied to the beta_p and li residuals.
+    regularization_weight : float, optional
+        Weight applied to the coefficient regularisation residual. Set to zero
+        to disable regularisation.
+    coefficient_scales : sequence of four floats, optional
+        Scaling applied to the coefficient regularisation residual.
+    use_metric_jacobian : bool, optional
+        If true, build an explicit finite-difference metric Jacobian for the
+        optimiser. This is more expensive but usually reduces optimiser steps
+        for nearby targets.
+    metric_jacobian : array-like, optional
+        Reusable physical Jacobian ``d[beta_p, li] / d[alpha0, alpha1, beta0,
+        beta1]``. If supplied, this constant Jacobian is used directly.
+    jacobian_rel_step : float, optional
+        Relative coefficient perturbation used by the explicit metric Jacobian.
+
+    Returns
+    -------
+    profiles : Lao85
+        Fitted Lao profile object after a final static solve.
+    result : LaoBetapLiFitResult
+        Fit diagnostics and raw optimiser result.
+    """
+
+    alpha = _validate_lao_pair("alpha", [1.0, -0.5] if alpha is None else alpha)
+    beta = _validate_lao_pair("beta", [1.0, -0.5] if beta is None else beta)
+
+    if not hasattr(eq, li_method):
+        raise ValueError(f"Equilibrium object has no li method '{li_method}'.")
+
+    solve_kwargs = {} if solve_kwargs is None else dict(solve_kwargs)
+    optimizer_kwargs = {} if optimizer_kwargs is None else dict(optimizer_kwargs)
+
+    x0 = np.concatenate((alpha, beta)).astype(float)
+    if residual_scales is None:
+        residual_scales = np.array([max(abs(betap), 1e-12), max(abs(li), 1e-12)])
+    else:
+        residual_scales = np.asarray(residual_scales, dtype=float)
+        if residual_scales.shape != (2,):
+            raise ValueError("residual_scales must contain two values.")
+        if np.any(residual_scales <= 0):
+            raise ValueError("residual_scales entries must be positive.")
+
+    if coefficient_scales is None:
+        coefficient_scales = np.maximum(np.abs(x0), 1.0)
+    else:
+        coefficient_scales = np.asarray(coefficient_scales, dtype=float)
+        if coefficient_scales.shape != (4,):
+            raise ValueError("coefficient_scales must contain four values.")
+        if np.any(coefficient_scales <= 0):
+            raise ValueError("coefficient_scales entries must be positive.")
+
+    evaluations = []
+    calculated_metric_jacobian = [None]
+    if metric_jacobian is not None:
+        metric_jacobian = np.asarray(metric_jacobian, dtype=float)
+        if metric_jacobian.shape != (2, 4):
+            raise ValueError("metric_jacobian must have shape (2, 4).")
+
+    def build_profiles(coefficients):
+        coefficients = np.asarray(coefficients, dtype=float)
+        return Lao85(
+            eq,
+            Ip=Ip,
+            fvac=fvac,
+            alpha=coefficients[:2],
+            beta=coefficients[2:],
+            alpha_logic=alpha_logic,
+            beta_logic=beta_logic,
+            Raxis=Raxis,
+            Ip_logic=True,
+        )
+
+    def evaluate_metric_residual(coefficients, record=True):
+        profiles = build_profiles(coefficients)
+        try:
+            static_solver.forward_solve(
+                eq,
+                profiles,
+                target_relative_tolerance,
+                max_solving_iterations=max_solving_iterations,
+                suppress=True,
+                **solve_kwargs,
+            )
+            _sync_profile_flux_normalisation(eq, profiles)
+            current_betap = eq.poloidalBeta1()
+            current_li = getattr(eq, li_method)()
+            scaled_residual = (
+                np.array([current_betap - betap, current_li - li], dtype=float)
+                / residual_scales
+            )
+            if record:
+                evaluations.append(
+                    {
+                        "coefficients": np.asarray(coefficients, dtype=float).copy(),
+                        "betap": current_betap,
+                        "li": current_li,
+                        "failed": False,
+                    }
+                )
+        except Exception as exc:
+            scaled_residual = np.array([1e6, 1e6], dtype=float)
+            if record:
+                evaluations.append(
+                    {
+                        "coefficients": np.asarray(coefficients, dtype=float).copy(),
+                        "betap": None,
+                        "li": None,
+                        "failed": True,
+                        "error": repr(exc),
+                    }
+                )
+
+        return scaled_residual
+
+    def objective(coefficients):
+        scaled_residual = evaluate_metric_residual(coefficients)
+        if regularization_weight:
+            regularization = (
+                np.sqrt(regularization_weight)
+                * (np.asarray(coefficients, dtype=float) - x0)
+                / coefficient_scales
+            )
+            return np.concatenate((scaled_residual, regularization))
+
+        return scaled_residual
+
+    def append_regularization_jacobian(scaled_metric_jacobian):
+        if regularization_weight:
+            regularization_jacobian = np.sqrt(regularization_weight) * np.diag(
+                1.0 / coefficient_scales
+            )
+            return np.vstack((scaled_metric_jacobian, regularization_jacobian))
+
+        return scaled_metric_jacobian
+
+    def constant_metric_jacobian(coefficients):
+        del coefficients
+        scaled_metric_jacobian = metric_jacobian / residual_scales[:, np.newaxis]
+        return append_regularization_jacobian(scaled_metric_jacobian)
+
+    def finite_difference_metric_jacobian(coefficients):
+        coefficients = np.asarray(coefficients, dtype=float)
+        scaled_metric_jacobian = np.zeros((2, len(coefficients)))
+
+        base_plasma_psi = np.copy(eq.plasma_psi)
+        base_solved = getattr(eq, "solved", None)
+
+        for i, coefficient in enumerate(coefficients):
+            step = jacobian_rel_step * max(abs(coefficient), coefficient_scales[i])
+            if step == 0:
+                step = jacobian_rel_step
+
+            plus = coefficients.copy()
+            plus[i] += step
+            _restore_equilibrium_solver_state(eq, base_plasma_psi, base_solved)
+            plus_residual = evaluate_metric_residual(plus, record=False)
+
+            minus = coefficients.copy()
+            minus[i] -= step
+            _restore_equilibrium_solver_state(eq, base_plasma_psi, base_solved)
+            minus_residual = evaluate_metric_residual(minus, record=False)
+
+            scaled_metric_jacobian[:, i] = (plus_residual - minus_residual) / (
+                2.0 * step
+            )
+
+        _restore_equilibrium_solver_state(eq, base_plasma_psi, base_solved)
+        calculated_metric_jacobian[0] = (
+            scaled_metric_jacobian * residual_scales[:, np.newaxis]
+        )
+
+        return append_regularization_jacobian(scaled_metric_jacobian)
+
+    optimizer_kwargs.setdefault("max_nfev", 30)
+    if metric_jacobian is not None:
+        optimizer_kwargs.setdefault("jac", constant_metric_jacobian)
+    elif use_metric_jacobian:
+        optimizer_kwargs.setdefault("jac", finite_difference_metric_jacobian)
+    optimizer_result = least_squares(objective, x0, **optimizer_kwargs)
+
+    if (
+        use_metric_jacobian
+        and metric_jacobian is None
+        and calculated_metric_jacobian[0] is None
+    ):
+        finite_difference_metric_jacobian(optimizer_result.x)
+
+    profiles = build_profiles(optimizer_result.x)
+    static_solver.forward_solve(
+        eq,
+        profiles,
+        target_relative_tolerance,
+        max_solving_iterations=max_solving_iterations,
+        suppress=True,
+        **solve_kwargs,
+    )
+    _sync_profile_flux_normalisation(eq, profiles)
+
+    result = LaoBetapLiFitResult(
+        alpha=optimizer_result.x[:2].copy(),
+        beta=optimizer_result.x[2:].copy(),
+        effective_alpha=profiles.alpha.copy(),
+        effective_beta=profiles.beta.copy(),
+        alpha_logic=alpha_logic,
+        beta_logic=beta_logic,
+        target_betap=betap,
+        final_betap=eq.poloidalBeta1(),
+        target_li=li,
+        final_li=getattr(eq, li_method)(),
+        li_method=li_method,
+        metric_jacobian=(
+            metric_jacobian
+            if metric_jacobian is not None
+            else calculated_metric_jacobian[0]
+        ),
+        optimizer_result=optimizer_result,
+        evaluations=evaluations,
+    )
+
+    return profiles, result
+
+
+def _validate_lao_pair(name, values):
+    """Return a validated two-coefficient Lao parameter vector."""
+    values = np.asarray(values, dtype=float)
+    if values.shape != (2,):
+        raise ValueError(
+            f"{name} must contain exactly two coefficients before Lao logic is applied."
+        )
+    return values
+
+
+def _sync_profile_flux_normalisation(eq, profiles):
+    """Ensure solved profile copies retain flux-axis normalisation fields."""
+    if hasattr(profiles, "inputs"):
+        psi_axis = profiles.inputs[0]
+        psi_bndry = profiles.inputs[1]
+    else:
+        psi_axis = getattr(profiles, "psi_axis", getattr(eq, "psi_axis", None))
+        psi_bndry = getattr(profiles, "psi_bndry", getattr(eq, "psi_bndry", None))
+
+    for target in (profiles, getattr(eq, "_profiles", None)):
+        if target is None:
+            continue
+        if psi_axis is not None and not hasattr(target, "psi_axis"):
+            target.psi_axis = psi_axis
+        if psi_bndry is not None and not hasattr(target, "psi_bndry"):
+            target.psi_bndry = psi_bndry
+
+    if hasattr(eq, "_profiles"):
+        eq._profiles = profiles.copy()
+
+
+def _restore_equilibrium_solver_state(eq, plasma_psi, solved):
+    """Restore the minimal equilibrium state that static solves mutate."""
+    eq.plasma_psi = np.copy(plasma_psi)
+    if solved is not None:
+        eq.solved = solved
 
 
 class TensionSpline(freegs4e.jtor.TensionSpline, Jtor_universal):

--- a/freegsnke/nonlinear_solve.py
+++ b/freegsnke/nonlinear_solve.py
@@ -31,6 +31,7 @@ from scipy.signal import convolve2d
 from . import nk_solver_H as nk_solver
 from .circuit_eq_metal import metal_currents
 from .GSstaticsolver import NKGSsolver
+from .jtor_update import fit_lao85_betap_li_ip
 from .linear_solve import linear_solver
 from .Myy_builder import Myy_handler
 from .simplified_solve import simplified_solver_J1
@@ -195,6 +196,8 @@ class nl_solver:
             target_relative_tolerance=target_relative_tolerance_linearization,
             verbose=False,
         )
+        self.lao_betap_li_fit_results = []
+        self._lao_betap_li_metric_jacobian = None
         print("-----")
 
         # set internal copy of the equilibrium and profile
@@ -2752,7 +2755,165 @@ class nl_solver:
         r_res_GS = a_res_GS / self.d_plasma_psi_step
         return r_res_GS
 
-    def check_and_change_profiles(self, profiles_parameters=None):
+    def lao85_betap_li_to_profiles_parameters(
+        self, profiles_parameters, profile_constraint_options=None
+    ):
+        """Convert Lao85 ``betap``/``li`` targets into ``alpha``/``beta`` coefficients.
+
+        The evolutive solver linearisation is built with respect to the Lao
+        profile coefficients. This helper lets users prescribe a more physical
+        profile schedule using ``profiles_parameters={"betap": ..., "li": ...}``;
+        internally, a static target fit is performed on the auxiliary
+        equilibrium and the resulting Lao coefficients are passed through the
+        existing coefficient-evolution path.
+
+        Parameters
+        ----------
+        profiles_parameters : dict or None
+            Profile update dictionary supplied to :meth:`nlstepper`.
+        profile_constraint_options : dict or None
+            Optional settings forwarded to :func:`fit_lao85_betap_li_ip`. Common
+            entries are ``li_method``, ``target_relative_tolerance``,
+            ``max_solving_iterations``, ``optimizer_kwargs``,
+            ``regularization_weight``, ``use_metric_jacobian``,
+            ``reuse_metric_jacobian``, and ``linearized_metric_update``.
+
+        Returns
+        -------
+        dict or None
+            A profile update dictionary containing fitted ``alpha`` and ``beta``
+            entries when beta_p/li targets were supplied. Dictionaries without
+            beta_p/li targets are returned unchanged.
+        """
+
+        if profiles_parameters is None:
+            return None
+
+        profiles_parameters = dict(profiles_parameters)
+        has_betap = "betap" in profiles_parameters or "beta_p" in profiles_parameters
+        has_li = "li" in profiles_parameters
+        if not (has_betap or has_li):
+            return profiles_parameters
+
+        if self.profiles_type != "Lao85":
+            raise ValueError(
+                "The {'betap', 'li'} profile-constraint route is only available "
+                "for Lao85 profiles. Other profile classes should continue to "
+                "receive their native profile parameters."
+            )
+
+        if "alpha" in profiles_parameters or "beta" in profiles_parameters:
+            raise ValueError(
+                "Provide either Lao85 coefficient updates ('alpha'/'beta') or "
+                "physical target updates ('betap'/'li'), not both."
+            )
+
+        options = (
+            {}
+            if profile_constraint_options is None
+            else dict(profile_constraint_options)
+        )
+        li_method = options.pop("li_method", "internalInductance2")
+        reuse_metric_jacobian = options.pop("reuse_metric_jacobian", True)
+        use_metric_jacobian = options.pop("use_metric_jacobian", True)
+        linearized_metric_update = options.pop("linearized_metric_update", False)
+        linearized_metric_regularization = options.pop(
+            "linearized_metric_regularization", 1e-8
+        )
+        linearized_metric_step_fraction = options.pop(
+            "linearized_metric_step_fraction", 1.0
+        )
+        if linearized_metric_step_fraction <= 0:
+            raise ValueError("linearized_metric_step_fraction must be positive.")
+        solve_kwargs = options.pop("solve_kwargs", None)
+        optimizer_kwargs = options.pop("optimizer_kwargs", None)
+
+        if "betap" in profiles_parameters and "beta_p" in profiles_parameters:
+            raise ValueError("Use only one of 'betap' or 'beta_p'.")
+        if "betap" in profiles_parameters:
+            target_betap = profiles_parameters.pop("betap")
+        elif "beta_p" in profiles_parameters:
+            target_betap = profiles_parameters.pop("beta_p")
+        else:
+            target_betap = self.eq1.poloidalBeta1()
+
+        if "li" in profiles_parameters:
+            target_li = profiles_parameters.pop("li")
+        else:
+            target_li = getattr(self.eq1, li_method)()
+        target_ip = profiles_parameters.get("Ip", self.profiles1.Ip)
+
+        initial_alpha = self.profiles1.alpha[: self.n_profiles_parameters_alpha]
+        initial_beta = self.profiles1.beta[: self.n_profiles_parameters_beta]
+
+        if (
+            linearized_metric_update
+            and reuse_metric_jacobian
+            and self._lao_betap_li_metric_jacobian is not None
+        ):
+            current_metrics = np.array(
+                [self.eq1.poloidalBeta1(), getattr(self.eq1, li_method)()],
+                dtype=float,
+            )
+            target_metrics = np.array([target_betap, target_li], dtype=float)
+            metric_jacobian = np.asarray(
+                self._lao_betap_li_metric_jacobian, dtype=float
+            )
+            metric_matrix = metric_jacobian @ metric_jacobian.T
+            metric_matrix += linearized_metric_regularization * np.eye(
+                metric_matrix.shape[0]
+            )
+            coefficient_step = metric_jacobian.T @ np.linalg.solve(
+                metric_matrix, target_metrics - current_metrics
+            )
+            coefficient_step *= linearized_metric_step_fraction
+            profiles_parameters["alpha"] = initial_alpha + coefficient_step[:2]
+            profiles_parameters["beta"] = initial_beta + coefficient_step[2:]
+            return profiles_parameters
+
+        scratch_eq = self.eq2
+        scratch_plasma_psi = np.copy(scratch_eq.plasma_psi)
+        scratch_solved = getattr(scratch_eq, "solved", None)
+        metric_jacobian = (
+            self._lao_betap_li_metric_jacobian if reuse_metric_jacobian else None
+        )
+
+        try:
+            _, fit_result = fit_lao85_betap_li_ip(
+                scratch_eq,
+                self.NK,
+                Ip=target_ip,
+                fvac=self.fvac,
+                betap=target_betap,
+                li=target_li,
+                alpha=initial_alpha,
+                beta=initial_beta,
+                alpha_logic=self.profiles1.alpha_logic,
+                beta_logic=self.profiles1.beta_logic,
+                li_method=li_method,
+                Raxis=getattr(self.profiles1, "Raxis", 1),
+                solve_kwargs=solve_kwargs,
+                optimizer_kwargs=optimizer_kwargs,
+                use_metric_jacobian=use_metric_jacobian,
+                metric_jacobian=metric_jacobian,
+                **options,
+            )
+        finally:
+            scratch_eq.plasma_psi = scratch_plasma_psi
+            if scratch_solved is not None:
+                scratch_eq.solved = scratch_solved
+
+        if fit_result.metric_jacobian is not None:
+            self._lao_betap_li_metric_jacobian = fit_result.metric_jacobian
+        self.lao_betap_li_fit_results.append(fit_result)
+
+        profiles_parameters["alpha"] = fit_result.alpha
+        profiles_parameters["beta"] = fit_result.beta
+        return profiles_parameters
+
+    def check_and_change_profiles(
+        self, profiles_parameters=None, profile_constraint_options=None
+    ):
         """
         Updates the plasma current profile parameters at time t+dt if new values are provided.
 
@@ -2768,6 +2929,11 @@ class nl_solver:
             Dictionary of profile parameters to update. Keys and values should match the
             attributes of the profile object (see `get_profiles_values` for structure).
             If None, no changes are made and the profiles remain unchanged.
+            For Lao85 profiles, users may alternatively provide ``betap`` and
+            ``li`` targets. These are fitted to Lao ``alpha`` and ``beta``
+            coefficients before the timestep is advanced.
+        profile_constraint_options : dict or None, optional
+            Options used when fitting Lao85 ``betap``/``li`` targets.
 
         Notes
         -----
@@ -2778,6 +2944,10 @@ class nl_solver:
         self.profiles_change_flag = 0
 
         if profiles_parameters is not None:
+            profiles_parameters = self.lao85_betap_li_to_profiles_parameters(
+                profiles_parameters,
+                profile_constraint_options=profile_constraint_options,
+            )
             for par in profiles_parameters:
                 setattr(self.profiles1, par, profiles_parameters[par])
                 setattr(self.profiles2, par, profiles_parameters[par])
@@ -2827,6 +2997,7 @@ class nl_solver:
         self,
         active_voltage_vec,
         profiles_parameters=None,
+        profile_constraint_options=None,
         plasma_resistivity=None,
         target_relative_tol_currents=0.005,
         target_relative_tol_GS=0.003,
@@ -2890,6 +3061,18 @@ class nl_solver:
             Voltages applied to the active coils between ``t`` and ``t + dt_step``.
         profiles_parameters : dict or None, optional
             Parameters to update the profile model. If None, profiles are unchanged.
+            Lao85 profiles may be updated either with native ``alpha``/``beta``
+            coefficients or with physical targets ``betap`` and ``li``. Physical
+            targets are fitted to Lao coefficients before the timestep is
+            advanced, so the linearised evolution still uses ``dIy/dtheta`` with
+            respect to the Lao coefficients.
+        profile_constraint_options : dict or None, optional
+            Options used when converting Lao85 ``betap``/``li`` targets to
+            ``alpha``/``beta``. Common entries are ``li_method``,
+            ``target_relative_tolerance``, ``max_solving_iterations``,
+            ``optimizer_kwargs``, ``regularization_weight``,
+            ``use_metric_jacobian``, ``reuse_metric_jacobian``, and
+            ``linearized_metric_update``.
         plasma_resistivity : float or array-like, optional
             New plasma resistivity. If None, resistivity remains unchanged.
         target_relative_tol_currents : float, default=0.005
@@ -3022,6 +3205,7 @@ class nl_solver:
         # and action the change where necessary
         self.check_and_change_profiles(
             profiles_parameters=profiles_parameters,
+            profile_constraint_options=profile_constraint_options,
         )
 
         self.check_and_change_active_coil_resistances(

--- a/freegsnke/tests/test_jtor_update.py
+++ b/freegsnke/tests/test_jtor_update.py
@@ -1,11 +1,12 @@
 import os
+from types import SimpleNamespace
 
 import freegs4e
 import numpy as np
 import pytest
 
 import freegsnke.jtor_update as jtor
-from freegsnke import build_machine, equilibrium_update
+from freegsnke import build_machine, equilibrium_update, nonlinear_solve
 
 
 @pytest.fixture()
@@ -76,3 +77,204 @@ def test_profiles_BetapIp(create_machine):
         and hasattr(profiles, "opt")
         and hasattr(profiles, "jtor")
     ), "The profiles object does not have the xpt, opt and jtor attributes"
+
+
+class _MinimalLimiterHandler:
+    """Limiter data required when instantiating a Lao85 profile."""
+
+    def __init__(self, shape):
+        self.mask_inside_limiter = np.ones(shape, dtype=bool)
+        self.limiter_mask_out = np.zeros(shape, dtype=bool)
+
+    def make_layer_mask(self, mask, layer_size=1):
+        return np.zeros_like(mask, dtype=bool)
+
+
+class _MinimalEquilibrium:
+    """Small equilibrium-like object for testing Lao beta_p/li fitting."""
+
+    def __init__(self):
+        r = np.linspace(0.8, 1.2, 3)
+        z = np.linspace(-0.2, 0.2, 3)
+        self.R, self.Z = np.meshgrid(r, z, indexing="ij")
+        self.R_1D = self.R[:, 0]
+        self.Z_1D = self.Z[0, :]
+        self.limiter_handler = _MinimalLimiterHandler(self.R.shape)
+        self.plasma_psi = np.zeros_like(self.R)
+        self.solved = False
+        self._betap = 0.0
+        self._li = 0.0
+
+    def poloidalBeta1(self):
+        return self._betap
+
+    def internalInductance2(self):
+        return self._li
+
+
+class _LinearProfileMetricSolver:
+    """Static-solver stand-in with deterministic profile-dependent metrics."""
+
+    def forward_solve(self, eq, profiles, *args, **kwargs):
+        alpha = profiles.alpha[:2]
+        beta = profiles.beta[:2]
+        eq._betap = alpha[0] + 2.0 * beta[0]
+        eq._li = alpha[1] - beta[1]
+
+
+class _LaoProfileLike:
+    """Small Lao-like profile object used by the evolutive conversion test."""
+
+    def __init__(self):
+        self.Ip = 1.0
+        self.fvac = 1.0
+        self.Raxis = 1.0
+        self.alpha_logic = True
+        self.beta_logic = True
+        self.alpha = np.array([1.0, -0.5, -0.5])
+        self.beta = np.array([0.5, -0.25, -0.25])
+
+    def initialize_profile(self):
+        if self.alpha_logic and len(self.alpha) == 2:
+            self.alpha = np.concatenate((self.alpha, [-np.sum(self.alpha)]))
+        if self.beta_logic and len(self.beta) == 2:
+            self.beta = np.concatenate((self.beta, [-np.sum(self.beta)]))
+
+
+def test_fit_lao85_betap_li_ip_handles_logic_flags():
+    """Fits two Lao alpha and beta coefficients before optional logic terms."""
+    eq = _MinimalEquilibrium()
+    solver = _LinearProfileMetricSolver()
+
+    profiles, result = jtor.fit_lao85_betap_li_ip(
+        eq,
+        solver,
+        Ip=1.0,
+        fvac=1.0,
+        betap=1.4,
+        li=0.4,
+        alpha=[0.0, 0.0],
+        beta=[0.0, 0.0],
+        alpha_logic=True,
+        beta_logic=False,
+        regularization_weight=0.0,
+        use_metric_jacobian=True,
+        optimizer_kwargs={"max_nfev": 20},
+    )
+
+    assert np.isclose(result.final_betap, result.target_betap, rtol=1e-3)
+    assert np.isclose(result.final_li, result.target_li, rtol=1e-3)
+    assert len(result.alpha) == 2
+    assert len(result.beta) == 2
+    assert len(result.effective_alpha) == 3
+    assert len(result.effective_beta) == 2
+    assert np.isclose(result.effective_alpha[-1], -np.sum(result.alpha))
+    assert np.allclose(profiles.alpha, result.effective_alpha)
+    assert np.allclose(profiles.beta, result.effective_beta)
+
+
+def test_fit_lao85_betap_li_ip_requires_two_input_coefficients():
+    """Rejects Lao coefficient vectors that already include logic terms."""
+    eq = _MinimalEquilibrium()
+    solver = _LinearProfileMetricSolver()
+
+    with pytest.raises(ValueError, match="exactly two coefficients"):
+        jtor.fit_lao85_betap_li_ip(
+            eq,
+            solver,
+            Ip=1.0,
+            fvac=1.0,
+            betap=1.0,
+            li=1.0,
+            alpha=[1.0, 0.0, -1.0],
+            beta=[1.0, 0.0],
+        )
+
+
+def test_nl_solver_converts_lao85_betap_li_targets(monkeypatch):
+    """Converts physical Lao targets before the existing coefficient update path."""
+    solver = object.__new__(nonlinear_solve.nl_solver)
+    solver.profiles_type = "Lao85"
+    solver.profiles1 = _LaoProfileLike()
+    solver.profiles2 = _LaoProfileLike()
+    solver.n_profiles_parameters_alpha = 2
+    solver.n_profiles_parameters_beta = 2
+    solver.eq1 = _MinimalEquilibrium()
+    solver.eq2 = _MinimalEquilibrium()
+    solver.eq2.plasma_psi[:] = 3.0
+    solver.eq2.solved = True
+    solver.NK = object()
+    solver.fvac = 1.0
+    solver.lao_betap_li_fit_results = []
+    solver._lao_betap_li_metric_jacobian = None
+
+    def fake_fit(eq, static_solver, **kwargs):
+        eq.plasma_psi[:] = 9.0
+        result = SimpleNamespace(
+            alpha=np.array([2.0, -0.25]),
+            beta=np.array([0.3, -0.1]),
+            metric_jacobian=np.ones((2, 4)),
+            target_betap=kwargs["betap"],
+            target_li=kwargs["li"],
+        )
+        return object(), result
+
+    monkeypatch.setattr(nonlinear_solve, "fit_lao85_betap_li_ip", fake_fit)
+
+    solver.check_and_change_profiles(
+        profiles_parameters={"betap": 0.7, "li": 0.8},
+        profile_constraint_options={"optimizer_kwargs": {"max_nfev": 2}},
+    )
+
+    assert np.allclose(solver.profiles1.alpha, [2.0, -0.25, -1.75])
+    assert np.allclose(solver.profiles1.beta, [0.3, -0.1, -0.2])
+    assert np.allclose(solver.profiles2.alpha, solver.profiles1.alpha)
+    assert np.allclose(solver.eq2.plasma_psi, 3.0)
+    assert solver.eq2.solved is True
+    assert solver.profiles_change_flag == 1
+    assert len(solver.lao_betap_li_fit_results) == 1
+    assert np.allclose(solver._lao_betap_li_metric_jacobian, np.ones((2, 4)))
+
+
+def test_nl_solver_can_reuse_cached_metric_jacobian(monkeypatch):
+    """Uses a cached beta_p/li metric Jacobian without another static fit."""
+    solver = object.__new__(nonlinear_solve.nl_solver)
+    solver.profiles_type = "Lao85"
+    solver.profiles1 = _LaoProfileLike()
+    solver.profiles2 = _LaoProfileLike()
+    solver.n_profiles_parameters_alpha = 2
+    solver.n_profiles_parameters_beta = 2
+    solver.eq1 = _MinimalEquilibrium()
+    solver.eq1._betap = 0.2
+    solver.eq1._li = 0.6
+    solver.eq2 = _MinimalEquilibrium()
+    solver.NK = object()
+    solver.fvac = 1.0
+    solver.lao_betap_li_fit_results = []
+    solver._lao_betap_li_metric_jacobian = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+        ]
+    )
+
+    def fake_fit(*args, **kwargs):
+        raise AssertionError("The cached linearized metric path should be used.")
+
+    monkeypatch.setattr(nonlinear_solve, "fit_lao85_betap_li_ip", fake_fit)
+
+    solver.check_and_change_profiles(
+        profiles_parameters={"betap": 0.25, "li": 0.55},
+        profile_constraint_options={
+            "linearized_metric_update": True,
+            "linearized_metric_regularization": 0.0,
+            "linearized_metric_step_fraction": 0.5,
+        },
+    )
+
+    assert np.allclose(solver.profiles1.alpha, [1.025, -0.525, -0.5])
+    assert np.allclose(solver.profiles1.beta, [0.5, -0.25, -0.25])
+    assert np.allclose(solver.profiles2.alpha, solver.profiles1.alpha)
+    assert np.allclose(solver.profiles2.beta, solver.profiles1.beta)
+    assert solver.lao_betap_li_fit_results == []
+    assert solver.profiles_change_flag == 1


### PR DESCRIPTION
## Summary
- add a Lao85 beta_p/li-to-alpha/beta fitting helper for static and evolutive workflows
- allow the nonlinear stepper to accept beta_p/li profile targets with cached metric-Jacobian reuse
- add example11b showing the pulse design workflow with constant beta_p/li targets and a tracking plot
- add regression tests for the fitter, nonlinear conversion, and cached linearized update path

## Verification
- pytest freegsnke/tests/test_jtor_update.py -q
- python -m py_compile freegsnke/jtor_update.py freegsnke/nonlinear_solve.py freegsnke/equilibrium_update.py
- executed examples/example11b - pulse_design_tool_betap_li.ipynb top-to-bottom with nbconvert