### PR TITLE
ROBUSTNESS: synchronize coil state during current assignment

### DIFF
--- a/freegsnke/nonlinear_solve.py
+++ b/freegsnke/nonlinear_solve.py
@@ -2811,7 +2811,8 @@ class nl_solver:
             Vector of current values to assign. Format:
                 (active coil currents, vessel normal mode currents, total plasma current / plasma_norm_factor)
         eq : FreeGSNKE equilibrium Object
-            Equilibrium object to be modified. Its `_current` attribute and `tokamak.current_vec` are updated.
+            Equilibrium object to be modified. Its `_current` attribute and tokamak
+            coil currents are updated.
         profiles : FreeGSNKE profiles Object
             Profiles object to be modified. Its total plasma current `Ip` is updated.
 
@@ -2829,7 +2830,7 @@ class nl_solver:
         self.vessel_currents_vec = self.evol_metal_curr.IdtoIvessel(
             Id=currents_vec[:-1]
         )
-        eq.tokamak.current_vec = self.vessel_currents_vec.copy()
+        eq.tokamak.set_all_coil_currents(self.vessel_currents_vec)
 
     def assign_currents_solve_GS(self, currents_vec, rtol_NK):
         """

--- a/freegsnke/tests/test_nonlinear_current_assignment.py
+++ b/freegsnke/tests/test_nonlinear_current_assignment.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from freegsnke.nonlinear_solve import nl_solver
+
+
+class _TokamakWithSeparateCurrentState:
+    """Minimal stand-in for Machine's cache and per-coil current storage."""
+
+    def __init__(self, size):
+        self.current_vec = np.zeros(size)
+        self.coil_currents = np.zeros(size)
+
+    def set_all_coil_currents(self, currents):
+        self.current_vec = np.asarray(currents, dtype=float).copy()
+        self.coil_currents = np.asarray(currents, dtype=float).copy()
+
+
+def test_assign_currents_synchronises_tokamak_current_state():
+    solver = object.__new__(nl_solver)
+    solver.plasma_norm_factor = 1.0e5
+    solver.evol_metal_curr = SimpleNamespace(
+        IdtoIvessel=lambda Id: 2.0 * np.asarray(Id, dtype=float)
+    )
+
+    tokamak = _TokamakWithSeparateCurrentState(size=3)
+    eq = SimpleNamespace(tokamak=tokamak, _current=0.0)
+    profiles = SimpleNamespace(Ip=0.0)
+    currents = np.array([1.0, -2.0, 3.0, 4.0])
+
+    solver.assign_currents(currents, eq, profiles)
+
+    expected_metal_currents = np.array([2.0, -4.0, 6.0])
+    np.testing.assert_array_equal(tokamak.current_vec, expected_metal_currents)
+    np.testing.assert_array_equal(tokamak.coil_currents, expected_metal_currents)
+    assert eq._current == 4.0e5
+    assert profiles.Ip == 4.0e5


### PR DESCRIPTION
## Summary

- route nonlinear-solver current assignment through `Machine.set_all_coil_currents`
- keep the cached machine current vector and individual coil objects synchronized
- add a focused regression test for both current representations and plasma-current assignment

## Motivation

`nl_solver.assign_currents()` previously wrote only `tokamak.current_vec`. Consumers such as `getCurrentsVec()` reconstruct this vector from individual coil objects, so less-protected calling paths could recover stale currents and overwrite the newly assigned state.

The current Example 11 accepted-step path already performs an explicit synchronization. A full baseline-versus-corrected run was therefore bit-for-bit identical, including its relinearisation at 0.065 s. This PR is framed as a robustness correction to the lower-level assignment contract rather than a correction to the published Example 11 trajectory.

## Verification

- focused current-assignment regression: passed
- existing `test_linearised_stepper`: passed
- full Example 11 baseline/corrected comparison: identical currents, plasma current, shape descriptors, and relinearisation behaviour