### PR TITLE
Keep plasma flux interpolation synchronized

### DIFF
--- a/freegsnke/GSstaticsolver.py
+++ b/freegsnke/GSstaticsolver.py
@@ -987,7 +987,7 @@ class NKGSsolver:
                 self.Z,
                 (self.tokamak_psi + trial_plasma_psi).reshape(self.nx, self.ny),
             )
-        eq.plasma_psi = trial_plasma_psi.reshape(self.nx, self.ny).copy()
+        eq.set_plasma_psi(trial_plasma_psi.reshape(self.nx, self.ny))
         self.port_critical(eq=eq, profiles=profiles)
 
         # ------------------------------------------------------------

--- a/freegsnke/equilibrium_update.py
+++ b/freegsnke/equilibrium_update.py
@@ -44,10 +44,8 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
         if self.equilibrium_path is not None:
             self.initialize_from_equilibrium()
 
-        # redefine interpolating function
-        self.psi_func_interp = interpolate.RectBivariateSpline(
-            self.R[:, 0], self.Z[0, :], self.plasma_psi
-        )
+        # Retain FreeGSNKE's checked interpolator after FreeGS4E initialisation.
+        self._refresh_plasma_psi_interpolator()
 
         self.nxh = len(self.R) // 2
         self.nyh = len(self.Z[0]) // 2
@@ -69,6 +67,23 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
         """Update plasma flux while retaining the checked FreeGSNKE interpolator."""
         super()._updatePlasmaPsi(plasma_psi)
         self.psi_func_interp = self.__dict__.pop("psi_func")
+
+    def _refresh_plasma_psi_interpolator(self):
+        """Rebuild the plasma-flux spline without recalculating plasma topology."""
+        self.psi_func_interp = interpolate.RectBivariateSpline(
+            self.R[:, 0], self.Z[0, :], self.plasma_psi
+        )
+
+    def set_plasma_psi(self, plasma_psi):
+        """Install plasma flux and synchronise its interpolation cache.
+
+        Unlike FreeGS4E's ``_updatePlasmaPsi``, this lightweight update does not
+        recalculate critical points, masks, or boundary flux. Solvers should use
+        it when committing a flux map before updating topology through their
+        existing profile-aware path.
+        """
+        self.plasma_psi = np.array(plasma_psi, copy=True)
+        self._refresh_plasma_psi_interpolator()
 
     def update_machine_description(
         self,
@@ -557,7 +572,7 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
                 # except:
                 #     diverted_flag = True
 
-        self.plasma_psi = n_plasma_psi.copy()
+        self.set_plasma_psi(n_plasma_psi)
 
     def psi_func(self, R, Z, *args, **kwargs):
         """Scipy interpolation of plasma_psi function.
@@ -587,10 +602,7 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
             print(
                 "Dicrepancy between psi_func and plasma_psi detected. psi_func has been re-set."
             )
-            # redefine interpolating function
-            self.psi_func_interp = interpolate.RectBivariateSpline(
-                self.R[:, 0], self.Z[0, :], self.plasma_psi
-            )
+            self._refresh_plasma_psi_interpolator()
 
         return self.psi_func_interp(R, Z, *args, **kwargs)
 
@@ -634,7 +646,7 @@ class Equilibrium(freegs4e.equilibrium.Equilibrium):
         )
 
         # extract the values on the grid given in the eq object (this is the initial guess)
-        self.plasma_psi = plasma_psi_func(self.R, self.Z, grid=False)
+        self.set_plasma_psi(plasma_psi_func(self.R, self.Z, grid=False))
 
         print(
             "Initial guess for plasma flux initialised using file provided at EQUILIBRIUM_PATH."

--- a/freegsnke/nonlinear_solve.py
+++ b/freegsnke/nonlinear_solve.py
@@ -2783,7 +2783,7 @@ class nl_solver:
             self.profiles1 = self.profiles2.copy()
             self.eq1 = self.eq2.create_auxiliary_equilibrium()
         else:
-            self.eq1.plasma_psi = np.copy(self.trial_plasma_psi)
+            self.eq1.set_plasma_psi(self.trial_plasma_psi)
             self.profiles1.Ip = self.trial_currents[-1] * self.plasma_norm_factor
             self.tokamak_psi = self.eq1.tokamak.calcPsiFromGreens(
                 pgreen=self.eq1._pgreen

--- a/freegsnke/tests/test_static_solver.py
+++ b/freegsnke/tests/test_static_solver.py
@@ -101,6 +101,18 @@ def create_machine():
     return eq, profiles, constrain
 
 
+def test_set_plasma_psi_refreshes_interpolator(create_machine):
+    eq, _, _ = create_machine
+    plasma_psi = np.zeros_like(eq.plasma_psi)
+    i, j = eq.nxh + 2, eq.nyh
+    plasma_psi[i, j] = 42.0
+
+    eq.set_plasma_psi(plasma_psi)
+
+    assert "psi_func" not in eq.__dict__
+    assert np.isclose(eq.psi_func(eq.R[i, j], eq.Z[i, j], grid=False), 42.0)
+
+
 def create_test_files_static_solve(create_machine):
     """
     Saves the control currents and psi map needed for testing the static solver.


### PR DESCRIPTION
## Summary

- add a lightweight `Equilibrium.set_plasma_psi()` path that updates the plasma-flux array and interpolation cache together
- use it when static and evolutive solvers commit externally visible equilibrium states
- keep FreeGS4E's `_updatePlasmaPsi()` topology and mask updates unchanged
- add an off-centre regression that the previous centre-point stale-cache check could miss

The spline is rebuilt only when a completed state is installed, not for temporary Newton, finite-difference, or Picard trial arrays. Linear-only evolution without a GS update leaves `plasma_psi` unchanged and therefore needs no refresh.

Direct external assignment to `eq.plasma_psi` still bypasses synchronization; callers replacing the array should use `eq.set_plasma_psi(...)`.

## Validation

- static solver tests: 5 passed
- full suite: 70 passed, 4 skipped; the two sandbox-blocked multiprocessing tests pass when run with process permissions
- virtual-circuit test file: 6 passed

Fixes #114
